### PR TITLE
Adding reduction and alkylation agents

### DIFF
--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -4041,6 +4041,98 @@ is_a: PRIDE:0000514 ! Quantification channel label
 creation_date: 2020-05-12T11:58:52Z
 
 [Term]
+id: PRIDE:0000598
+name: Alkylation reagent
+def: "The alkylation reagent that is used to covalently modify cysteine SH-groups after reduction, preventing them from forming unwanted novel disulfide bonds"
+is_a: PRIDE:0000026 ! Alkylation
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000599
+name: Iodoacetamide (IAA)
+def: "The alkylation reagent 2-iodoacetamide with the chemical formula - C2H4INO. The corresponding mass shift at the cysteine residue (UNIMODE Accession # 4) - 57.021 Da"
+is_a: PRIDE:0000598 ! Alkylation reagent
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000600
+name: Chloroacetamide (ClAA)
+def: "The alkylation reagent 2-chloroacetamide with the chemical formula - C2H4ClNO. The corresponding mass shift at the cysteine residue (UNIMODE Accession # 4) - 57.021 Da"
+is_a: PRIDE:0000598 ! Alkylation reagent
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000601
+name: Iodoacetic acid (IAC)
+def: "The derivative of acetic acid with the chemical formula - C2H3IO2. The corresponding mass shift at the cysteine residue (UNIMODE Accession # 6)- 58.005 Da"
+is_a: PRIDE:0000598 ! Alkylation reagent
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000602
+name: Chloroacetic acid (ClAC)
+def: "The derivative of acetic acid with the chemical formula - C2H3ClO2. The corresponding mass shift at the cysteine residue (UNIMODE Accession # 6)- 58.005 Da"
+is_a: PRIDE:0000598 ! Alkylation reagent
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000603
+name: Acrylamide (AA)
+def: "The alkylation reagent acrylamide (or acrylic amide) with the chemical formula - C3H5NO. The corresponding mass shift at the cysteine residue (UNIMODE Accession # 24) - 71.037 Da"
+is_a: PRIDE:0000598 ! Alkylation reagent
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000604
+name: 4-Vinylpyridine (4-VP)
+def: "The derivative of pyridine with a vinyl group in the 4-position with the chemical formula - C7H7N. The corresponding mass shift at the cysteine residue (UNIMODE Accession # 31) - 105.058 Da"
+is_a: PRIDE:0000598 ! Alkylation reagent
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000605
+name: Methyl methanethiosulfonate (MMTS)
+def: "The alkylation reagent that can reversibly sulfenylate thiol-containing molecules, chemical formula - C2H6O2S2. The corresponding mass shift at the cysteine residue (UNIMODE Accession # 39) - 45.988 Da"
+is_a: PRIDE:0000598 ! Alkylation reagent
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000606
+name: N-ethylmaleimide (NEM)
+def: "The derivative of maleic acid, chemical formula - C6H7NO2. The corresponding mass shift at the cysteine residue (UNIMODE Accession # 108) - 125.048 Da"
+is_a: PRIDE:0000598 ! Alkylation reagent
+created_by: lisavetasol
+
+[Term]
+id: PRIDE:0000607
+name: Reduction reagent
+def: "The chemical reagent that is used to break disulfide bonds in proteins"
+is_a: PRIDE:0000025 ! Reduction
+created_by: lisavetasol 
+
+[Term]
+id: PRIDE:0000608
+name: Dithiothreitol (DTT)
+def: "The commonly used small redox reagent dithiothreitol (also known as Cleland's reagent) with chemical formula C4H10O2S2"
+is_a: PRIDE:0000607 ! Reduction reagent
+created_by: lisavetasol 
+
+[Term]
+id: PRIDE:0000609
+name: Tris(2-carboxyethyl)phosphine (TCEP)
+def: "The reduction agent with chemincal formuls C9H15O6P"
+is_a: PRIDE:0000607 ! Reduction reagent
+created_by: lisavetasol 
+
+[Term]
+id: PRIDE:0000610
+name: Beta-mercaptoethanol (BME)
+def: "The reduction agent 2-mercaptoethanol (2-sulfanylethan-1-ol) with chemincal formuls C2H6OS"
+is_a: PRIDE:0000607 ! Reduction reagent
+created_by: lisavetasol 
+
+
+[Term]
 id: PRIDE:0000000
 name: Reference additional parameter
 property_value: http://purl.obolibrary.org/obo/comment "Root node for terms relating to Reference additional parameters, in the context of ExperimentCollection/Experiment/Reference/additional/CvParam" xsd:string


### PR DESCRIPTION
Added 2 subclasses - alkylation reagent and reduction reagent. The particular reagent names are added under the corresponding class. In total, 3 reduction reagents (DDT, TCEP, and BME) and 8 alkylation reagents (IAA, ClAA, IAC, ClAC, AA, 4-VP, MMTS and NEM) are described. 
The PR relates to [issue #331](https://github.com/bigbio/proteomics-metadata-standard/issues/331)