### PR TITLE
Add "Glycoproteomics" experiment type

### DIFF
--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -4004,7 +4004,7 @@ is_a: PRIDE:0000663 ! technology type
 [Term]
 id: PRIDE:0000665
 name: Glycoproteomics
-def: "Study of proteins that identifies, catalogs, and characterizes those proteins that contain carbohydrates as posttranslational modifications."
+def: "Study of proteins that identifies, catalogs, and characterizes those proteins that contain carbohydrates as posttranslational modifications." [PRIDE:PRIDE]
 is_a: PRIDE:0000457! Experiment Type
 
 

--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -1,7 +1,7 @@
 format-version: 1.4
-date: 11:10:2024 11:38
-data-version: 2.1.4
-saved-by: Yasset Perez-Riverol
+date: 11:11:2024 13:18
+data-version: 2.1.5
+saved-by: Nithu Sara John
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: PRIDE
 remark: I would set treat-xrefs-as-equivalent but there are some weird xrefs that would break that behaviour (PRIDE:PRIDE, value-type:xsd\:string, ...)
@@ -4000,6 +4000,13 @@ id: PRIDE:0000664
 name: proteomic profiling by mass spectrometry
 def: "An assay where proteins in a sample are detected, quantified or otherwise analysed using mass spectrometry" [EFO:EFO_0002766]
 is_a: PRIDE:0000663 ! technology type
+
+[Term]
+id: PRIDE:0000665
+name: Glycoproteomics
+def: "Study of proteins that identifies, catalogs, and characterizes those proteins that contain carbohydrates as posttranslational modifications."
+is_a: PRIDE:0000457! Experiment Type
+
 
 [Typedef]
 id: http://purl.obolibrary.org/obo/PRIDE_part_of


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Added a new experiment type "Glycoproteomics" to the ontology, including its definition and classification.
- Updated metadata fields such as date, data-version, and saved-by to reflect the latest changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pride_cv.obo</strong><dd><code>Add Glycoproteomics experiment type to ontology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pride_cv.obo

<li>Updated metadata including date, data-version, and saved-by fields.<br> <li> Added a new term for "Glycoproteomics" with its definition and <br>classification.<br>


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/pride-ontology/pull/113/files#diff-a0aa916f263b3df520de95c3b47eace77bbaa05edb0914ee42d95574e9c9c7be">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information