### PR TITLE
Remove terms that are not supported anymore

### DIFF
--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -366,14 +366,14 @@ is_a: PRIDE:0000573 ! Identification software
 [Term]
 id: PRIDE:0000057
 name: Molecular weight
-def: "Molecular weight of a protein." [PRIDE:PRIDE]
+def: "Molecular weight of a protein" [PRIDE:PRIDE]
 is_a: PRIDE:0000008 ! Protein search engine output parameter
 relationship: part_of PRIDE:0000056 ! Bioworks
 
 [Term]
 id: PRIDE:0000058
 name: z score
-def: Bioworks z score
+def: "Bioworks z score" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000056 ! Bioworks
 

--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -1,7 +1,7 @@
 format-version: 1.4
 date: 13:02:2025 10:31
-data-version: 2.1.8
-saved-by: Nithu Sara John
+data-version: 2.1.10
+saved-by: Yasset Perez-Riverol
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: PRIDE
 remark: I would set treat-xrefs-as-equivalent but there are some weird xrefs that would break that behaviour (PRIDE:PRIDE, value-type:xsd\:string, ...)
@@ -372,7 +372,8 @@ relationship: part_of PRIDE:0000056 ! Bioworks
 
 [Term]
 id: PRIDE:0000058
-name: z
+name: z score
+def: Bioworks z score
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000056 ! Bioworks
 
@@ -558,11 +559,6 @@ is_a: PRIDE:0000071 ! Search engine setting
 id: PRIDE:0000088
 name: Protonated setting MH+
 def: "protonated setting MH⁺ refers to the protonated molecular ion of a compound, where M represents the neutral molecule, and the H⁺ signifies the added proton." [PRIDE;PRIDE]
-is_a: PRIDE:0000087 ! Protonated setting
-
-[Term]
-id: PRIDE:0000089
-name: Protonated setting Mr
 is_a: PRIDE:0000087 ! Protonated setting
 
 [Term]
@@ -2260,126 +2256,6 @@ id: PRIDE:0000366
 name: Contains multiple subsamples
 def: "Identifies samples that are made up of multiplexed subsamples" [PRIDE:PRIDE]
 is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000367
-name: Subsample 1 description
-is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000368
-name: Subsample 2 description
-is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000369
-name: Subsample 3 description
-is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000370
-name: Subsample 4 description
-is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000371
-name: Subsample 5 description
-is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000372
-name: Subsample 6 description
-is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000373
-name: Subsample 7 description
-is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000374
-name: Subsample 8 description
-is_a: PRIDE:0000365 ! Multiplexed sample description
-
-[Term]
-id: PRIDE:0000375
-name: Standard deviation subsample 1
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000376
-name: Standard deviation subsample 2
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000377
-name: Standard deviation subsample 3
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000378
-name: Standard deviation subsample 4
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000379
-name: Standard deviation subsample 5
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000380
-name: Standard deviation subsample 6
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000381
-name: Standard deviation subsample 7
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000382
-name: Standard deviation subsample 8
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000383
-name: Standard error subsample 1
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000384
-name: Standard error subsample 2
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000385
-name: Standard error subsample 3
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000386
-name: Standard error subsample 4
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000387
-name: Standard error subsample 5
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000388
-name: Standard error subsample 6
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000389
-name: Standard error subsample 7
-is_a: PRIDE:0000353 ! Multiplexed quantification value
-
-[Term]
-id: PRIDE:0000390
-name: Standard error subsample 8
-is_a: PRIDE:0000353 ! Multiplexed quantification value
 
 [Term]
 id: PRIDE:0000391

--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -163,7 +163,7 @@ is_a: PRIDE:0000001 ! Protocol step description additional parameter
 [Term]
 id: PRIDE:0000025
 name: Reduction
-def: "reduction generally refers to the chemical process used to break disulfide bonds between cysteine residues in proteins" [PRIDE:PRIDE]
+def: "Reduction generally refers to the chemical process used to break disulfide bonds between cysteine residues in proteins" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
@@ -270,6 +270,7 @@ is_a: PRIDE:0000028 ! Cv Label
 [Term]
 id: PRIDE:0000043
 name: FIX
+def: "Valid value for the cvLabel entry referencing FIX" [PRIDE:PRIDE]
 is_a: PRIDE:0000028 ! Cv Label
 
 [Term]
@@ -329,14 +330,14 @@ relationship: part_of PRIDE:0000045 ! Sequest
 [Term]
 id: PRIDE:0000052
 name: Cn
-def: "normalized correlation score" [PRIDE:PRIDE]
+def: "Normalized correlation score" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
 [Term]
 id: PRIDE:0000053
 name: Sequest score
-def: "raw correlation score (Sequest)" [PRIDE:PRIDE]
+def: "Raw correlation score (Sequest)" [PRIDE:PRIDE]
 synonym: "C*10^4" RELATED []
 is_a: PRIDE:0000008 ! Protein search engine output parameter
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
@@ -345,14 +346,14 @@ relationship: part_of PRIDE:0000045 ! Sequest
 [Term]
 id: PRIDE:0000054
 name: Sp
-def: "preliminary score" [PRIDE:PRIDE]
+def: "Preliminary score" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
 [Term]
 id: PRIDE:0000055
 name: Ions
-def: "the number of frament ions matched (in the preliminary scoring process) out of the total number of fragment masses for the peptide" [PRIDE:PRIDE]
+def: "The number of frament ions matched (in the preliminary scoring process) out of the total number of fragment masses for the peptide" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
@@ -392,7 +393,7 @@ is_a: PRIDE:0000049 ! Peptide search engine output parameter
 [Term]
 id: PRIDE:0000061
 name: Coverage
-def: "coverage refers to the proportion of a protein sequence that is represented by identified peptides in a given experiment" [PRIDE:PRIDE]
+def: "Coverage refers to the proportion of a protein sequence that is represented by identified peptides in a given experiment" [PRIDE:PRIDE]
 is_a: PRIDE:0000008 ! Protein search engine output parameter
 relationship: part_of PRIDE:0000056 ! Bioworks
 
@@ -430,13 +431,13 @@ is_a: PRIDE:0000003 ! Peptide item additional parameter
 [Term]
 id: PRIDE:0000067
 name: Reference reporting this experiment
-def: "referencing an experiment in scientific contexts, it's important to cite the original publication that reports the methods, results, or analysis involved in the experiment. Typically, this will involve citing the DOI (Digital Object Identifier), journal title, and other relevant details" [PRIDE:PRIDE]
+def: "Referencing an experiment in scientific contexts, it's important to cite the original publication that reports the methods, results, or analysis involved in the experiment. Typically, this will involve citing the DOI (Digital Object Identifier), journal title, and other relevant details" [PRIDE:PRIDE]
 is_a: PRIDE:0000000 ! Reference additional parameter
 
 [Term]
 id: PRIDE:0000068
 name: Reference describing sample preparation
-def: "referencing sample preparation for mass spectrometry or proteomics, the specific protocols and methods can vary depending on the type of analysis being conducted (e.g., quantitative proteomics, post-translational modification analysis, etc.)" [PRIDE:PRIDE]
+def: "Referencing sample preparation for mass spectrometry or proteomics, the specific protocols and methods can vary depending on the type of analysis being conducted (e.g., quantitative proteomics, post-translational modification analysis, etc.)" [PRIDE:PRIDE]
 is_a: PRIDE:0000000 ! Reference additional parameter
 
 [Term]
@@ -462,13 +463,13 @@ is_a: PRIDE:0000003 ! Peptide item additional parameter
 [Term]
 id: PRIDE:0000072
 name: Fixed modification setting
-def: "fixed modifications refer to chemical modifications that are consistently present in all peptides of a given experiment, typically due to a sample preparation step or reagent used" [PRIDE:PRIDE]
+def: "Fixed modifications refer to chemical modifications that are consistently present in all peptides of a given experiment, typically due to a sample preparation step or reagent used" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000073
 name: Variable modification setting
-def: "variable modifications refer to post-translational modifications (PTMs) or other chemical changes that can occur at specific amino acid residues but do not necessarily occur in every peptide or protein" [PRIDE:PRIDE]
+def: "Variable modifications refer to post-translational modifications (PTMs) or other chemical changes that can occur at specific amino acid residues but do not necessarily occur in every peptide or protein" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
@@ -534,43 +535,43 @@ is_a: PRIDE:0000082 ! Mass error type setting
 [Term]
 id: PRIDE:0000084
 name: mass error type setting mmu
-def: "mass errors refer to discrepancies in the measured mass of ions compared to their theoretical or expected mass values" [PRIDE:PRIDE]
+def: "Mass errors refer to discrepancies in the measured mass of ions compared to their theoretical or expected mass values" [PRIDE:PRIDE]
 is_a: PRIDE:0000082 ! Mass error type setting
 
 [Term]
 id: PRIDE:0000085
 name: mass error type setting percent
-def: "mass error type setting percent refers to the percentage of mass error in the measured mass-to-charge ratio (m/z) compared to the expected or theoretical value" [PRIDE:PRIDE]
+def: "Mass error type setting percent refers to the percentage of mass error in the measured mass-to-charge ratio (m/z) compared to the expected or theoretical value" [PRIDE:PRIDE]
 is_a: PRIDE:0000082 ! Mass error type setting
 
 [Term]
 id: PRIDE:0000086
 name: mass error type setting Daltons
-def: "mass error type daltons, how the discrepancy between the measured and expected mass is expressed in absolute units of mass (daltons), rather than as a percentage" [PRIDE:PRIDE]
+def: "Mass error type daltons, how the discrepancy between the measured and expected mass is expressed in absolute units of mass (daltons), rather than as a percentage" [PRIDE:PRIDE]
 is_a: PRIDE:0000082 ! Mass error type setting
 
 [Term]
 id: PRIDE:0000087
 name: Protonated setting
-def: "protonated setting refers to the protonation of a molecule or ion during the ionization process, particularly in positive ion mode" [PRIDE:PRIDE]
+def: "Protonated setting refers to the protonation of a molecule or ion during the ionization process, particularly in positive ion mode" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000088
 name: Protonated setting MH+
-def: "protonated setting MH⁺ refers to the protonated molecular ion of a compound, where M represents the neutral molecule, and the H⁺ signifies the added proton" [PRIDE;PRIDE]
+def: "Protonated setting MH⁺ refers to the protonated molecular ion of a compound, where M represents the neutral molecule, and the H⁺ signifies the added proton" [PRIDE;PRIDE]
 is_a: PRIDE:0000087 ! Protonated setting
 
 [Term]
 id: PRIDE:0000090
 name: Protonated setting M-H-
-def: "protonated setting M-H⁻ refers to the deprotonated molecular ion (also known as the negative ion form), where M represents the neutral molecule, and H⁻ signifies the loss of a proton (H⁺), resulting in a negatively charged ion" [PRIDE:PRIDE]
+def: "Protonated setting M-H⁻ refers to the deprotonated molecular ion (also known as the negative ion form), where M represents the neutral molecule, and H⁻ signifies the loss of a proton (H⁺), resulting in a negatively charged ion" [PRIDE:PRIDE]
 is_a: PRIDE:0000087 ! Protonated setting
 
 [Term]
 id: PRIDE:0000091
 name: Rank
-def: "rank represents the quality or confidence of the peptide-spectrum match (PSM), with the rank value showing the best match and progressively lower-ranked results indicating less confident identifications" [PRIDE:PRIDE]
+def: "Rank represents the quality or confidence of the peptide-spectrum match (PSM), with the rank value showing the best match and progressively lower-ranked results indicating less confident identifications" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 
 [Term]
@@ -588,7 +589,7 @@ is_a: PRIDE:0000092 ! All peptides matched
 [Term]
 id: PRIDE:0000094
 name: All peptides matched false
-def: "some mass spectra from the experiment could not be linked to a known peptide sequence from the protein database" [PRIDE:PRIDE]
+def: "Some mass spectra from the experiment could not be linked to a known peptide sequence from the protein database" [PRIDE:PRIDE]
 is_a: PRIDE:0000092 ! All peptides matched
 
 [Term]
@@ -1018,19 +1019,19 @@ is_a: PRIDE:0000071 ! Search engine setting
 [Term]
 id: PRIDE:0000161
 name: Fragment mass tolerance setting
-def: "range of acceptable fragment masses accepted by instrument" [PRIDE:PRIDE]
+def: "Range of acceptable fragment masses accepted by instrument" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000162
 name: Allowed missed cleavages
-def: "number of missed cleavage sites taken into account" [PRIDE:PRIDE]
+def: "Number of missed cleavage sites taken into account" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000163
 name: Instrument type
-def: "name of instrument used in analysis" [PRIDE:PRIDE]
+def: "Name of instrument used in analysis" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
@@ -1180,42 +1181,42 @@ is_a: PRIDE:0000049 ! Peptide search engine output parameter
 id: PRIDE:0000187
 name: Fragment Ion Annotation
 def: "Fragment ion annotation of the peptide" [PRIDE:PRIDE]
-synonym: "product ion property" EXACT []
+synonym: "Product ion property" EXACT []
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000188
 name: product ion m/z
 def: "Mass" [PRIDE:PRIDE]
-synonym: "fragment ion mass" EXACT []
+synonym: "Fragment ion mass" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000189
 name: product ion intensity
 def: "Intensity" [PRIDE:PRIDE]
-synonym: "fragment ion intensity" EXACT []
+synonym: "Fragment ion intensity" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000190
 name: product ion mass error
 def: "Mass error" [PRIDE:PRIDE]
-synonym: "fragment ion mass error" EXACT []
+synonym: "Fragment ion mass error" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000191
 name: product ion retention time error
 def: "Retention time error in minutes" [PRIDE:PRIDE]
-synonym: "fragment ion retention time error" EXACT []
+synonym: "Fragment ion retention time error" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000192
 name: product ion type
 def: "Product ion type" [PRIDE:PRIDE]
-synonym: "fragment ion type" EXACT []
+synonym: "Fragment ion type" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
@@ -1229,21 +1230,21 @@ is_a: PRIDE:0000192 ! product ion type
 id: PRIDE:0000194
 name: b ion
 def: "B ion type" [PRIDE:PRIDE]
-synonym: "b fragment ion" EXACT []
+synonym: "B fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000195
 name: b ion -NH3
 def: "B ion type with a neutral loss of an ammonia group" [PRIDE:PRIDE]
-synonym: "b fragment ion -NH3" EXACT []
+synonym: "B fragment ion -NH3" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
 id: PRIDE:0000196
 name: b ion -H2O
 def: "B ion type with a neutral loss of a water molecule" [PRIDE:PRIDE]
-synonym: "b fragment ion -H2O" EXACT []
+synonym: "B fragment ion -H2O" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
@@ -1264,8 +1265,8 @@ is_a: PRIDE:0000193 ! y ion
 id: PRIDE:0000199
 name: in source ion
 def: "Ion resulting from in-source fragmentation" [PRIDE:PRIDE]
-synonym: "in source fragment ion" EXACT []
-synonym: "in-source ion" EXACT []
+synonym: "In source fragment ion" EXACT []
+synonym: "In-source ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
@@ -1297,7 +1298,7 @@ is_a: PRIDE:0000202 ! Parent Ion Annotation
 id: PRIDE:0000204
 name: product ion charge
 def: "Charge state" [PRIDE:PRIDE]
-synonym: "fragment ion charge" EXACT []
+synonym: "Fragment ion charge" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
@@ -1406,7 +1407,7 @@ is_a: PRIDE:0000202 ! Parent Ion Annotation
 [Term]
 id: PRIDE:0000222
 name: spectrum iTRAQ ratio
-def: "average iTRAQ ratio sample over control" [PRIDE:PRIDE]
+def: "Average iTRAQ ratio sample over control" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_obsolete: true
 
@@ -1484,42 +1485,42 @@ is_a: PRIDE:0000230 ! z ion
 id: PRIDE:0000233
 name: a ion
 def: "A ion type" [PRIDE:PRIDE]
-synonym: "a fragment ion" EXACT []
+synonym: "A fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000234
 name: a ion -H2O
 def: "A ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
-synonym: "a fragment ion -H2O" EXACT []
+synonym: "A fragment ion -H2O" EXACT []
 is_a: PRIDE:0000233 ! a ion
 
 [Term]
 id: PRIDE:0000235
 name: a ion -NH3
 def: "A ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
-synonym: "a fragment ion -NH3" EXACT []
+synonym: "A fragment ion -NH3" EXACT []
 is_a: PRIDE:0000233 ! a ion
 
 [Term]
 id: PRIDE:0000236
 name: c ion
 def: "C ion type" [PRIDE:PRIDE]
-synonym: "c fragment ion" EXACT []
+synonym: "C fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000237
 name: c ion -H2O
 def: "C ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
-synonym: "c fragment ion -H2O" EXACT []
+synonym: "C fragment ion -H2O" EXACT []
 is_a: PRIDE:0000236 ! c ion
 
 [Term]
 id: PRIDE:0000238
 name: c ion -NH3
 def: "C ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
-synonym: "c fragment ion -NH3" EXACT []
+synonym: "C fragment ion -NH3" EXACT []
 is_a: PRIDE:0000236 ! c ion
 
 [Term]
@@ -1651,29 +1652,29 @@ is_a: PRIDE:0000239 ! immonium ion
 [Term]
 id: PRIDE:0000260
 name: precursor ion type
-def: "precursor ion type" [PRIDE:PRIDE]
-synonym: "parent ion type" EXACT []
+def: "Precursor ion type" [PRIDE:PRIDE]
+synonym: "Parent ion type" EXACT []
 is_a: PRIDE:0000202 ! Parent Ion Annotation
 
 [Term]
 id: PRIDE:0000261
 name: precursor ion -H2O
 def: "Precursor ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
-synonym: "parent ion -H2O" EXACT []
+synonym: "Parent ion -H2O" EXACT []
 is_a: PRIDE:0000263 ! precursor ion
 
 [Term]
 id: PRIDE:0000262
 name: precursor ion -NH3
 def: "Precursor ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
-synonym: "parent ion -NH3" EXACT []
+synonym: "Parent ion -NH3" EXACT []
 is_a: PRIDE:0000263 ! precursor ion
 
 [Term]
 id: PRIDE:0000263
 name: precursor ion
 def: "Precursor ion" [PRIDE:PRIDE]
-synonym: "parent ion" EXACT []
+synonym: "Parent ion" EXACT []
 is_a: PRIDE:0000260 ! precursor ion type
 
 [Term]
@@ -1761,13 +1762,13 @@ is_a: PRIDE:0000044 ! Search algorithm
 [Term]
 id: PRIDE:0000277
 name: Valid location
-def: "a valid location refers to a site on a peptide or protein sequence that has been confidently identified as being modified" [PRIDE:PRIDE]
+def: "A valid location refers to a site on a peptide or protein sequence that has been confidently identified as being modified" [PRIDE:PRIDE]
 is_a: PRIDE:0000002 ! ModificationItem additional parameter
 
 [Term]
 id: PRIDE:0000278
 name: Processing method additional parameter
-def: "a processing method refers to the specific steps or algorithms used to analyze raw MS data, identify peptides, and assign modifications. These processing methods often come with additional parameters that allow users to customize the analysis based on their experimental needs" [PRIDE:PRIDE]
+def: "A processing method refers to the specific steps or algorithms used to analyze raw MS data, identify peptides, and assign modifications. These processing methods often come with additional parameters that allow users to customize the analysis based on their experimental needs" [PRIDE:PRIDE]
 
 [Term]
 id: PRIDE:0000279
@@ -2445,21 +2446,21 @@ is_a: PRIDE:0000004 ! Identification additional parameter
 id: PRIDE:0000419
 name: b ion -H3PO4
 def: "B ion type with a neutral loss of a phosphate molecule" [PRIDE:PRIDE]
-synonym: "b fragment ion -H3PO4" EXACT []
+synonym: "B fragment ion -H3PO4" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
 id: PRIDE:0000420
 name: b ion -2H3PO4
 def: "B ion type with a neutral loss of 2 phosphate molecules" [PRIDE:PRIDE]
-synonym: "b fragment ion -2H3PO4" EXACT []
+synonym: "B fragment ion -2H3PO4" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
 id: PRIDE:0000421
 name: b ion -3H3PO4
 def: "B ion type with a neutral loss of 3 phosphate molecules" [PRIDE:PRIDE]
-synonym: "b fragment ion -3H3PO4" EXACT []
+synonym: "B fragment ion -3H3PO4" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
@@ -2498,7 +2499,7 @@ is_a: PRIDE:0000006 ! Experiment additional parameter
 [Term]
 id: PRIDE:0000427
 name: Top-down proteomics
-def: "a mass spectrometry-based approach that analyzes intact proteins rather than digesting them into peptides (as in bottom-up proteomics)" [PRIDE:PRIDE]
+def: "A mass spectrometry-based approach that analyzes intact proteins rather than digesting them into peptides (as in bottom-up proteomics)" [PRIDE:PRIDE]
 is_a: PRIDE:0000426 ! Mass spectrometry proteomics experimental strategy
 is_a: PRIDE:0000457 ! Experiment Type
 
@@ -3252,7 +3253,7 @@ def: "Instrument properties" [PRIDE:PRIDE]
 [Term]
 id: MS:1000451
 name: mass analyzer
-def: "mass analyzer" [PRIDE:PRIDE]
+def: "Mass analyzer" [PRIDE:PRIDE]
 is_a: PRIDE:0000547 ! Instrument properties
 
 [Term]
@@ -3534,7 +3535,7 @@ is_a: PRIDE:0000645 ! MS3 dissociation method
 [Term]
 id: PRIDE:0000590
 name: HCD
-def: "beam-type collision-induced dissociation" [PRIDE:PRIDE]
+def: "Beam-type collision-induced dissociation" [PRIDE:PRIDE]
 is_a: MS:1000044 ! dissociation method
 is_a: PRIDE:0000644 ! MS2 dissociation method
 is_a: PRIDE:0000645 ! MS3 dissociation method
@@ -3542,7 +3543,7 @@ is_a: PRIDE:0000645 ! MS3 dissociation method
 [Term]
 id: PRIDE:0000591
 name: CID
-def: "collision-induced dissociation" [PRIDE:PRIDE]
+def: "Collision-induced dissociation" [PRIDE:PRIDE]
 is_a: MS:1000044 ! dissociation method
 is_a: PRIDE:0000644 ! MS2 dissociation method
 is_a: PRIDE:0000645 ! MS3 dissociation method
@@ -3593,7 +3594,7 @@ relationship: part_of PRIDE:0000592 ! ETciD
 [Term]
 id: PRIDE:0000597
 name: metabolic label
-def: "metabolic label" [PRIDE:PRIDE]
+def: "Metabolic label" [PRIDE:PRIDE]
 is_a: PRIDE:0000514 ! Quantification channel label
 
 [Term]
@@ -3952,7 +3953,7 @@ is_a: PRIDE:0000671 ! Olink Explore
 [Term]
 id: PRIDE:0000659
 name: Proteomics data acquisition method
-def: "proteomics data acquisition method" [PRIDE:PRIDE]
+def: "Proteomics data acquisition method" [PRIDE:PRIDE]
 is_a: PRIDE:0000428 ! Bottom-up proteomics
 
 [Term]

--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -52,13 +52,13 @@ def: "Root node for terms relating to the description of an Experiment in relati
 [Term]
 id: PRIDE:0000007
 name: SearchEngineVersion
-def: "Version number / identifier for search engine."[PRIDE:PRIDE]
+def: "Version number / identifier for search engine"[PRIDE:PRIDE]
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000008
 name: Protein search engine output parameter
-def: "Protein search engine output parameters are critical for analyzing and validating the results of peptide and protein identification." [PRIDE:PRIDE]
+def: "Protein search engine output parameters are critical for analyzing and validating the results of peptide and protein identification" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
@@ -83,7 +83,7 @@ is_a: PRIDE:0000009 ! Ion mass tolerance
 [Term]
 id: PRIDE:0000012
 name: Delta Cn
-def: "1.0 - normalized correlation score." [PRIDE:PRIDE]
+def: "1.0 - normalized correlation score" [PRIDE:PRIDE]
 is_a: PRIDE:0000008 ! Protein search engine output parameter
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
@@ -121,19 +121,19 @@ def: "Root term for parameters in the context of ExperimentCollection/Experiment
 [Term]
 id: PRIDE:0000018
 name: Disease free
-def: "Term to describe the fact that the sample derives from an organism which has been positively shown to be free of disease, e.g. as the consequence of a broad-spectrum screen.  NOTE: A request has been made to have this concept added to MeSH.  Once this has been achieved, this term will be dropped from the PRIDE CV and all uses of the this term will be updated to the appropriate MeSH concept." [PRIDE:PRIDE]
+def: "Term to describe the fact that the sample derives from an organism which has been positively shown to be free of disease, e.g. as the consequence of a broad-spectrum screen.  NOTE: A request has been made to have this concept added to MeSH.  Once this has been achieved, this term will be dropped from the PRIDE CV and all uses of the this term will be updated to the appropriate MeSH concept" [PRIDE:PRIDE]
 is_a: PRIDE:0000017 ! Sample description additional parameter
 
 [Term]
 id: PRIDE:0000019
 name: Solubilization
-def: "To make something soluble or more soluble, especially in water, by the action of a detergent or other agent." [PRIDE:PRIDE]
+def: "To make something soluble or more soluble, especially in water, by the action of a detergent or other agent" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
 id: PRIDE:0000020
 name: Depletion
-def: "The removal of specific components of a complex mixture of proteins or peptides on the basis of some specific property of those components." [PRIDE:PRIDE]
+def: "The removal of specific components of a complex mixture of proteins or peptides on the basis of some specific property of those components" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
@@ -145,19 +145,19 @@ is_a: PRIDE:0000001 ! Protocol step description additional parameter
 [Term]
 id: PRIDE:0000022
 name: Separation
-def: "To separate a complex mixture of proteins or peptides based on molecular characteristics and interaction type over a given amount of time." [PRIDE:PRIDE]
+def: "To separate a complex mixture of proteins or peptides based on molecular characteristics and interaction type over a given amount of time" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
 id: PRIDE:0000023
 name: Band excision
-def: "The removal of a region of a gel which contains protein(s) of interest." [PRIDE:PRIDE]
+def: "The removal of a region of a gel which contains protein(s) of interest" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
 id: PRIDE:0000024
 name: Enzyme digestion
-def: "The fragmentation of proteins into peptides through the use of an enzyme such as trypsin." [PRIDE:PRIDE]
+def: "The fragmentation of proteins into peptides through the use of an enzyme such as trypsin" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
@@ -169,19 +169,19 @@ is_a: PRIDE:0000001 ! Protocol step description additional parameter
 [Term]
 id: PRIDE:0000026
 name: Alkylation
-def: "The transfer of an alkyl group from one molecule to another." [PRIDE:PRIDE]
+def: "The transfer of an alkyl group from one molecule to another" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
 id: PRIDE:0000027
 name: Mass spectrometry
-def: "This is a measuring method consisting of turning elements in a sample into ions, isolating them according to the ratio between the mass and charge numbers and detecting it electrically." [PRIDE:PRIDE]
+def: "This is a measuring method consisting of turning elements in a sample into ions, isolating them according to the ratio between the mass and charge numbers and detecting it electrically" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
 id: PRIDE:0000028
 name: Cv Label
-def: "Valid values for cvLabel entries referencing external database / CV / ontology." [PRIDE:PRIDE]
+def: "Valid values for cvLabel entries referencing external database / CV / ontology" [PRIDE:PRIDE]
 
 [Term]
 id: PRIDE:0000029
@@ -198,7 +198,7 @@ is_a: PRIDE:0000028 ! Cv Label
 [Term]
 id: PRIDE:0000031
 name: GO
-def: "Valid value for the cvLabel entry referencing GO." [PRIDE:PRIDE]
+def: "Valid value for the cvLabel entry referencing GO" [PRIDE:PRIDE]
 is_a: PRIDE:0000028 ! Cv Label
 
 [Term]
@@ -210,7 +210,7 @@ is_a: PRIDE:0000028 ! Cv Label
 [Term]
 id: PRIDE:0000033
 name: NEWT
-def: "Valid value for the cvLabel entry referencing NEWT or the NCBI taxonomy." [PRIDE:PRIDE]
+def: "Valid value for the cvLabel entry referencing NEWT or the NCBI taxonomy" [PRIDE:PRIDE]
 is_a: PRIDE:0000028 ! Cv Label
 
 [Term]
@@ -228,7 +228,7 @@ is_a: PRIDE:0000028 ! Cv Label
 [Term]
 id: PRIDE:0000036
 name: RESID
-def: "Valid value for the cvLabel entry referencing RESID." [PRIDE:PRIDE]
+def: "Valid value for the cvLabel entry referencing RESID" [PRIDE:PRIDE]
 is_a: PRIDE:0000028 ! Cv Label
 
 [Term]
@@ -246,13 +246,13 @@ is_a: PRIDE:0000028 ! Cv Label
 [Term]
 id: PRIDE:0000039
 name: Organelle isolation
-def: "Any technique which separates differentiated structures from the cell." [PRIDE:PRIDE]
+def: "Any technique which separates differentiated structures from the cell" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
 id: PRIDE:0000040
 name: Experiment description
-def: "This CV term should be used in association with a value that is a free-text description of the experiment." [PRIDE:PRIDE]
+def: "This CV term should be used in association with a value that is a free-text description of the experiment" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
@@ -264,7 +264,7 @@ is_a: PRIDE:0000004 ! Identification additional parameter
 [Term]
 id: PRIDE:0000042
 name: DOI
-def: "The DOI system provides a persistent link to the journal's location on the internet, even if the URL changes." [PRIDE:PRIDE]
+def: "The DOI system provides a persistent link to the journal's location on the internet, even if the URL changes" [PRIDE:PRIDE]
 is_a: PRIDE:0000028 ! Cv Label
 
 [Term]
@@ -315,28 +315,28 @@ is_a: PRIDE:0000003 ! Peptide item additional parameter
 [Term]
 id: PRIDE:0000050
 name: Rank/Sp
-def: "Final correlation score rank and preliminary score rank." [PRIDE:PRIDE]
+def: "Final correlation score rank and preliminary score rank" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
 [Term]
 id: PRIDE:0000051
 name: (M+H)+
-def: "m/z of the singly-charged precursor (precursor mass + mass of hydrogen atom)." [PRIDE:PRIDE]
+def: "m/z of the singly-charged precursor (precursor mass + mass of hydrogen atom)" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
 [Term]
 id: PRIDE:0000052
 name: Cn
-def: "normalized correlation score." [PRIDE:PRIDE]
+def: "normalized correlation score" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
 [Term]
 id: PRIDE:0000053
 name: Sequest score
-def: "raw correlation score (Sequest)." [PRIDE:PRIDE]
+def: "raw correlation score (Sequest)" [PRIDE:PRIDE]
 synonym: "C*10^4" RELATED []
 is_a: PRIDE:0000008 ! Protein search engine output parameter
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
@@ -345,14 +345,14 @@ relationship: part_of PRIDE:0000045 ! Sequest
 [Term]
 id: PRIDE:0000054
 name: Sp
-def: "preliminary score." [PRIDE:PRIDE]
+def: "preliminary score" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
 [Term]
 id: PRIDE:0000055
 name: Ions
-def: "the number of frament ions matched (in the preliminary scoring process) out of the total number of fragment masses for the peptide." [PRIDE:PRIDE]
+def: "the number of frament ions matched (in the preliminary scoring process) out of the total number of fragment masses for the peptide" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
@@ -386,7 +386,7 @@ is_a: PRIDE:0000049 ! Peptide search engine output parameter
 [Term]
 id: PRIDE:0000060
 name: Scan
-def: "The scan refers to a unique identifier for a specific mass spectrum acquired during the experiment. Each scan corresponds to a particular fragmentation event in the mass spectrometer." [PRIDE:PRIDE]
+def: "The scan refers to a unique identifier for a specific mass spectrum acquired during the experiment. Each scan corresponds to a particular fragmentation event in the mass spectrometer" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 
 [Term]
@@ -399,7 +399,7 @@ relationship: part_of PRIDE:0000056 ! Bioworks
 [Term]
 id: PRIDE:0000062
 name: rsp
-def: "It is used as a measure to assess the confidence of peptide identifications based on the output of peptide search engines such as Mascot, SEQUEST, X! Tandem, and others." [PRIDE:PRIDE]
+def: "It is used as a measure to assess the confidence of peptide identifications based on the output of peptide search engines such as Mascot, SEQUEST, X! Tandem, and others" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000056 ! Bioworks
 
@@ -418,38 +418,38 @@ is_a: PRIDE:0000004 ! Identification additional parameter
 [Term]
 id: PRIDE:0000065
 name: Upstream flanking sequence
-def: "Any sequence reported before the start of the peptide." [PRIDE:PRIDE]
+def: "Any sequence reported before the start of the peptide" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000066
 name: Downstream flanking seqeuence
-def: "Any sequence reported after the end of the peptide sequence." [PRIDE:PRIDE]
+def: "Any sequence reported after the end of the peptide sequence" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000067
 name: Reference reporting this experiment
-def: "referencing an experiment in scientific contexts, it's important to cite the original publication that reports the methods, results, or analysis involved in the experiment. Typically, this will involve citing the DOI (Digital Object Identifier), journal title, and other relevant details." [PRIDE:PRIDE]
+def: "referencing an experiment in scientific contexts, it's important to cite the original publication that reports the methods, results, or analysis involved in the experiment. Typically, this will involve citing the DOI (Digital Object Identifier), journal title, and other relevant details" [PRIDE:PRIDE]
 is_a: PRIDE:0000000 ! Reference additional parameter
 
 [Term]
 id: PRIDE:0000068
 name: Reference describing sample preparation
-def: "referencing sample preparation for mass spectrometry or proteomics, the specific protocols and methods can vary depending on the type of analysis being conducted (e.g., quantitative proteomics, post-translational modification analysis, etc.)." [PRIDE:PRIDE]
+def: "referencing sample preparation for mass spectrometry or proteomics, the specific protocols and methods can vary depending on the type of analysis being conducted (e.g., quantitative proteomics, post-translational modification analysis, etc.)" [PRIDE:PRIDE]
 is_a: PRIDE:0000000 ! Reference additional parameter
 
 [Term]
 id: PRIDE:0000069
 name: Mascot score
-def: "Score as defined for the Mascot search algorithm." [PRIDE:PRIDE]
+def: "Score as defined for the Mascot search algorithm" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000046 ! Mascot
 
 [Term]
 id: PRIDE:0000070
 name: Peptide cleavage
-def: "Cleavage of the peptide bond." [PRIDE:PRIDE]
+def: "Cleavage of the peptide bond" [PRIDE:PRIDE]
 is_a: PRIDE:0000024 ! Enzyme digestion
 
 [Term]
@@ -462,7 +462,7 @@ is_a: PRIDE:0000003 ! Peptide item additional parameter
 [Term]
 id: PRIDE:0000072
 name: Fixed modification setting
-def: "fixed modifications refer to chemical modifications that are consistently present in all peptides of a given experiment, typically due to a sample preparation step or reagent used." [PRIDE:PRIDE]
+def: "fixed modifications refer to chemical modifications that are consistently present in all peptides of a given experiment, typically due to a sample preparation step or reagent used" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
@@ -486,13 +486,13 @@ is_a: PRIDE:0000071 ! Search engine setting
 [Term]
 id: PRIDE:0000076
 name: Mass value type setting monoisotopic
-def: "The monoisotopic mass setting refers to the mass of a molecule based on the lightest isotope of each element, typically the most abundant isotope, like carbon-12 (12C) for carbon, hydrogen-1 (1H) for hydrogen, and oxygen-16 (16O) for oxygen." [PRIDE:PRIDE]
+def: "The monoisotopic mass setting refers to the mass of a molecule based on the lightest isotope of each element, typically the most abundant isotope, like carbon-12 (12C) for carbon, hydrogen-1 (1H) for hydrogen, and oxygen-16 (16O) for oxygen" [PRIDE:PRIDE]
 is_a: PRIDE:0000075 ! Mass value type setting
 
 [Term]
 id: PRIDE:0000077
 name: Mass value type setting average
-def: "The average mass setting refers to the weighted average mass of all isotopes of each element present in a molecule." [PRIDE:PRIDE]
+def: "The average mass setting refers to the weighted average mass of all isotopes of each element present in a molecule" [PRIDE:PRIDE]
 is_a: PRIDE:0000075 ! Mass value type setting
 
 [Term]
@@ -504,7 +504,7 @@ is_a: PRIDE:0000071 ! Search engine setting
 [Term]
 id: PRIDE:0000079
 name: Accurate mass mode setting
-def: "The Accurate Mass Mode setting refers to a mode of operation where the mass spectrometer is configured to measure the mass of ions with a higher degree of precision than in standard scanning modes." [PRIDE:PRIDE]
+def: "The Accurate Mass Mode setting refers to a mode of operation where the mass spectrometer is configured to measure the mass of ions with a higher degree of precision than in standard scanning modes" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
@@ -516,13 +516,13 @@ is_a: PRIDE:0000079 ! Accurate mass mode setting
 [Term]
 id: PRIDE:0000081
 name: Accurate mass mode setting false
-def: "Accurate mass mode setting is set to false in mass spectrometry, it means that the instrument will not prioritize high-resolution mass measurements." [PRIDE:PRIDE]
+def: "Accurate mass mode setting is set to false in mass spectrometry, it means that the instrument will not prioritize high-resolution mass measurements" [PRIDE:PRIDE]
 is_a: PRIDE:0000079 ! Accurate mass mode setting
 
 [Term]
 id: PRIDE:0000082
 name: Mass error type setting
-def: "The mass error type setting refers to how mass errors are reported and interpreted during data acquisition and analysis." [PRIDE:PRIDE]
+def: "The mass error type setting refers to how mass errors are reported and interpreted during data acquisition and analysis" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
@@ -534,61 +534,61 @@ is_a: PRIDE:0000082 ! Mass error type setting
 [Term]
 id: PRIDE:0000084
 name: mass error type setting mmu
-def: "mass errors refer to discrepancies in the measured mass of ions compared to their theoretical or expected mass values." [PRIDE:PRIDE]
+def: "mass errors refer to discrepancies in the measured mass of ions compared to their theoretical or expected mass values" [PRIDE:PRIDE]
 is_a: PRIDE:0000082 ! Mass error type setting
 
 [Term]
 id: PRIDE:0000085
 name: mass error type setting percent
-def: "mass error type setting percent refers to the percentage of mass error in the measured mass-to-charge ratio (m/z) compared to the expected or theoretical value." [PRIDE:PRIDE]
+def: "mass error type setting percent refers to the percentage of mass error in the measured mass-to-charge ratio (m/z) compared to the expected or theoretical value" [PRIDE:PRIDE]
 is_a: PRIDE:0000082 ! Mass error type setting
 
 [Term]
 id: PRIDE:0000086
 name: mass error type setting Daltons
-def: "mass error type daltons, how the discrepancy between the measured and expected mass is expressed in absolute units of mass (daltons), rather than as a percentage." [PRIDE:PRIDE]
+def: "mass error type daltons, how the discrepancy between the measured and expected mass is expressed in absolute units of mass (daltons), rather than as a percentage" [PRIDE:PRIDE]
 is_a: PRIDE:0000082 ! Mass error type setting
 
 [Term]
 id: PRIDE:0000087
 name: Protonated setting
-def: "protonated setting refers to the protonation of a molecule or ion during the ionization process, particularly in positive ion mode." [PRIDE:PRIDE]
+def: "protonated setting refers to the protonation of a molecule or ion during the ionization process, particularly in positive ion mode" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000088
 name: Protonated setting MH+
-def: "protonated setting MH⁺ refers to the protonated molecular ion of a compound, where M represents the neutral molecule, and the H⁺ signifies the added proton." [PRIDE;PRIDE]
+def: "protonated setting MH⁺ refers to the protonated molecular ion of a compound, where M represents the neutral molecule, and the H⁺ signifies the added proton" [PRIDE;PRIDE]
 is_a: PRIDE:0000087 ! Protonated setting
 
 [Term]
 id: PRIDE:0000090
 name: Protonated setting M-H-
-def: "protonated setting M-H⁻ refers to the deprotonated molecular ion (also known as the negative ion form), where M represents the neutral molecule, and H⁻ signifies the loss of a proton (H⁺), resulting in a negatively charged ion." [PRIDE:PRIDE]
+def: "protonated setting M-H⁻ refers to the deprotonated molecular ion (also known as the negative ion form), where M represents the neutral molecule, and H⁻ signifies the loss of a proton (H⁺), resulting in a negatively charged ion" [PRIDE:PRIDE]
 is_a: PRIDE:0000087 ! Protonated setting
 
 [Term]
 id: PRIDE:0000091
 name: Rank
-def: "rank represents the quality or confidence of the peptide-spectrum match (PSM), with the rank value showing the best match and progressively lower-ranked results indicating less confident identifications." [PRIDE:PRIDE]
+def: "rank represents the quality or confidence of the peptide-spectrum match (PSM), with the rank value showing the best match and progressively lower-ranked results indicating less confident identifications" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 
 [Term]
 id: PRIDE:0000092
 name: All peptides matched
-def: "the output of a peptide search engine where every peptide in a sample has been identified and matched against a database." [PRIDE:PRIDE]
+def: "the output of a peptide search engine where every peptide in a sample has been identified and matched against a database" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 
 [Term]
 id: PRIDE:0000093
 name: All peptides matched true
-def: "All peptides matched true is in a peptide search engine output (like Mascot, SEQUEST, X! Tandem, or Andromeda), it generally means that all detected peptide spectra were successfully matched to corresponding peptides in the protein database." [PRIDE:PRIDE]
+def: "All peptides matched true is in a peptide search engine output (like Mascot, SEQUEST, X! Tandem, or Andromeda), it generally means that all detected peptide spectra were successfully matched to corresponding peptides in the protein database" [PRIDE:PRIDE]
 is_a: PRIDE:0000092 ! All peptides matched
 
 [Term]
 id: PRIDE:0000094
 name: All peptides matched false
-def: "some mass spectra from the experiment could not be linked to a known peptide sequence from the protein database." [PRIDE:PRIDE]
+def: "some mass spectra from the experiment could not be linked to a known peptide sequence from the protein database" [PRIDE:PRIDE]
 is_a: PRIDE:0000092 ! All peptides matched
 
 [Term]
@@ -600,105 +600,105 @@ is_a: PRIDE:0000049 ! Peptide search engine output parameter
 [Term]
 id: PRIDE:0000096
 name: Reported Chromosome
-def: "Reported chromosome is the chromosomal location of the protein or peptide that has been identified." [PRIDE:PRIDE]
+def: "Reported chromosome is the chromosomal location of the protein or peptide that has been identified" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000097
 name: Project
-def: "Allows experiments to be grouped or organised under projects.  Experiments may be grouped under more than one project." [PRIDE:PRIDE]
+def: "Allows experiments to be grouped or organised under projects.  Experiments may be grouped under more than one project" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000098
 name: Indistinguishable alternative protein accession
-def: "A qualifier is mandatory when using this term.  The qualifier is an alternative protein accession that is indistinguishable from the primary protein accession based upon observed peptide sequences only." [PRIDE:PRIDE]
+def: "A qualifier is mandatory when using this term.  The qualifier is an alternative protein accession that is indistinguishable from the primary protein accession based upon observed peptide sequences only" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000099
 name: PeptideProphet probability score
-def: "The probability score for this peptide assignment to be correct, as calculated by PeptideProphet." [PRIDE:PRIDE]
+def: "The probability score for this peptide assignment to be correct, as calculated by PeptideProphet" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000101 ! PeptideProphet
 
 [Term]
 id: PRIDE:0000100
 name: ProteinProphet probability score
-def: "The probability score for this protein identification to be correct, as calculated by ProteinProphet." [PRIDE:PRIDE]
+def: "The probability score for this protein identification to be correct, as calculated by ProteinProphet" [PRIDE:PRIDE]
 is_a: PRIDE:0000008 ! Protein search engine output parameter
 relationship: part_of PRIDE:0000102 ! ProteinProphet
 
 [Term]
 id: PRIDE:0000101
 name: PeptideProphet
-def: "The PeptideProphet algorithm." [PRIDE:PRIDE]
+def: "The PeptideProphet algorithm" [PRIDE:PRIDE]
 is_a: PRIDE:0000044 ! Search algorithm
 
 [Term]
 id: PRIDE:0000102
 name: ProteinProphet
-def: "The ProteinProphet algorithm." [PRIDE:PRIDE]
+def: "The ProteinProphet algorithm" [PRIDE:PRIDE]
 is_a: PRIDE:0000044 ! Search algorithm
 
 [Term]
 id: PRIDE:0000103
 name: Gel run date
-def: "The date upon which the gel was run.  A value is mandatory - must be formatted as xsd:dateTime." [PRIDE:PRIDE]
+def: "The date upon which the gel was run.  A value is mandatory - must be formatted as xsd:dateTime" [PRIDE:PRIDE]
 is_a: PRIDE:0000005 ! Gel additional parameter
 
 [Term]
 id: PRIDE:0000104
 name: Sample volume loaded
-def: "The volume of sample loaded on to the gel measured in micro litres.  Mandatory value must be formatted as xsd:Double." [PRIDE:PRIDE]
+def: "The volume of sample loaded on to the gel measured in micro litres.  Mandatory value must be formatted as xsd:Double" [PRIDE:PRIDE]
 is_a: PRIDE:0000005 ! Gel additional parameter
 
 [Term]
 id: PRIDE:0000105
 name: Width in pixels
-def: "The width of the referenced gel image in pixels.  Mandatory value of type xsd:int." [PRIDE:PRIDE]
+def: "The width of the referenced gel image in pixels.  Mandatory value of type xsd:int" [PRIDE:PRIDE]
 is_a: PRIDE:0000005 ! Gel additional parameter
 
 [Term]
 id: PRIDE:0000106
 name: Height in pixels
-def: "The height of the referenced gel image in pixels.  Mandatory value of type xsd:int." [PRIDE:PRIDE]
+def: "The height of the referenced gel image in pixels.  Mandatory value of type xsd:int" [PRIDE:PRIDE]
 is_a: PRIDE:0000005 ! Gel additional parameter
 
 [Term]
 id: PRIDE:0000107
 name: Gel spot parameter
-def: "Parameters describing the spot on a gel that has been analysed resulting in the annotated protein identification." [PRIDE:PRIDE]
+def: "Parameters describing the spot on a gel that has been analysed resulting in the annotated protein identification" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000108
 name: Gel spot intensity
-def: "The intensity of the spot on the gel.   Mandatory value of type xsd:double." [PRIDE:PRIDE]
+def: "The intensity of the spot on the gel.   Mandatory value of type xsd:double" [PRIDE:PRIDE]
 is_a: PRIDE:0000107 ! Gel spot parameter
 
 [Term]
 id: PRIDE:0000109
 name: Gel spot area 
-def: "The area of the spot on the gel measured in millimetres squared.   Mandatory value of type xsd:double." [PRIDE:PRIDE]
+def: "The area of the spot on the gel measured in millimetres squared.   Mandatory value of type xsd:double" [PRIDE:PRIDE]
 is_a: PRIDE:0000107 ! Gel spot parameter
 
 [Term]
 id: PRIDE:0000110
 name: Gel spot volume
-def: "The volume of the spot on the gel measured in millimetres cubed.  Mandatory value of type xsd:double." [PRIDE:PRIDE]
+def: "The volume of the spot on the gel measured in millimetres cubed.  Mandatory value of type xsd:double" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000131 ! Spot normalized volume
 
 [Term]
 id: PRIDE:0000111
 name: Reference describing data analysis
-def: "A reference annotated with this term describes analysis of the data presented in the enclosing PRIDE experiment." [PRIDE:PRIDE]
+def: "A reference annotated with this term describes analysis of the data presented in the enclosing PRIDE experiment" [PRIDE:PRIDE]
 is_a: PRIDE:0000000 ! Reference additional parameter
 
 [Term]
 id: PRIDE:0000112
 name: Identified by peptide mass fingerprint
-def: "The annotated protein identification arises from peptide mass fingerprinting.  Peptide identifications may or may not be included." [PRIDE:PRIDE]
+def: "The annotated protein identification arises from peptide mass fingerprinting.  Peptide identifications may or may not be included" [PRIDE:PRIDE]
 synonym: "PMF" EXACT []
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_a: PRIDE:0000004 ! Identification additional parameter
@@ -706,7 +706,7 @@ is_a: PRIDE:0000004 ! Identification additional parameter
 [Term]
 id: PRIDE:0000113
 name: Identified by peptide fragmentation
-def: "The protein identification annotated with this term has been identified by peptide fragmentation and subsequent database searching." [PRIDE:PRIDE]
+def: "The protein identification annotated with this term has been identified by peptide fragmentation and subsequent database searching" [PRIDE:PRIDE]
 synonym: "PFF" EXACT []
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_a: PRIDE:0000004 ! Identification additional parameter
@@ -714,73 +714,73 @@ is_a: PRIDE:0000004 ! Identification additional parameter
 [Term]
 id: PRIDE:0000114
 name: iTRAQ reagent 114
-def: "The name of the sample labelled with iTRAQ reagent 114." [PRIDE:PRIDE]
+def: "The name of the sample labelled with iTRAQ reagent 114" [PRIDE:PRIDE]
 is_a: PRIDE:0000329 ! iTRAQ reagent
 
 [Term]
 id: PRIDE:0000115
 name: iTRAQ reagent 115
-def: "The name of the sample labelled with iTRAQ reagent 115." [PRIDE:PRIDE]
+def: "The name of the sample labelled with iTRAQ reagent 115" [PRIDE:PRIDE]
 is_a: PRIDE:0000329 ! iTRAQ reagent
 
 [Term]
 id: PRIDE:0000116
 name: iTRAQ reagent 116
-def: "The name of the sample labelled with iTRAQ reagent 116." [PRIDE:PRIDE]
+def: "The name of the sample labelled with iTRAQ reagent 116" [PRIDE:PRIDE]
 is_a: PRIDE:0000329 ! iTRAQ reagent
 
 [Term]
 id: PRIDE:0000117
 name: iTRAQ reagent 117
-def: "The name of the sample labelled with iTRAQ reagent 117." [PRIDE:PRIDE]
+def: "The name of the sample labelled with iTRAQ reagent 117" [PRIDE:PRIDE]
 is_a: PRIDE:0000329 ! iTRAQ reagent
 
 [Term]
 id: PRIDE:0000118
 name: iTRAQ intensity 114
-def: "The intensity of the sample labelled with iTRAQ reagent 114." [PRIDE:PRIDE]
+def: "The intensity of the sample labelled with iTRAQ reagent 114" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000119
 name: iTRAQ intensity 115
-def: "The intensity of the sample labelled with iTRAQ reagent 115." [PRIDE:PRIDE]
+def: "The intensity of the sample labelled with iTRAQ reagent 115" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000120
 name: iTRAQ intensity 116
-def: "The intensity of the sample labelled with iTRAQ reagent 116." [PRIDE:PRIDE]
+def: "The intensity of the sample labelled with iTRAQ reagent 116" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000121
 name: iTRAQ intensity 117
-def: "The intensity of the sample labelled with iTRAQ reagent 117." [PRIDE:PRIDE]
+def: "The intensity of the sample labelled with iTRAQ reagent 117" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000122
 name: Two Dimensional Polyacrylamide Gel Electrophoresis
-def: "A type of gel electrophoresis in which proteins are first separated by charge and then by molecular weight, enabling the analysis of complex protein mixtures." [PRIDE:PRIDE]
+def: "A type of gel electrophoresis in which proteins are first separated by charge and then by molecular weight, enabling the analysis of complex protein mixtures" [PRIDE:PRIDE]
 is_a: PRIDE:0000022 ! Separation
 
 
 [Term]
 id: PRIDE:0000123
 name: Immobilized pH Gradient Electrophoresis
-def: "Electrophoresis using an gel  which has a  pH gradient along its length." [PRIDE:PRIDE]
+def: "Electrophoresis using an gel  which has a  pH gradient along its length" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000122 ! Two Dimensional Polyacrylamide Gel Electrophoresis
 is_a: PRIDE:0000568 ! 2D PAGE
 
 [Term]
 id: PRIDE:0000124
 name: Sodium dodecyl sulfate polyacrylamide gel electrophoresis
-def: "A type of polyacrylamide gel electrophoresis in which the anionic detergent sodium dodecyl sulfate (SDS) is used to denature the sample proteins into linear monomers, rendering their charge proportional to their length so that migration is a function of size. Abbreviated SDS-polyacrylamide gel electrophoresis or SDS-PAGE." [PRIDE:PRIDE]
+def: "A type of polyacrylamide gel electrophoresis in which the anionic detergent sodium dodecyl sulfate (SDS) is used to denature the sample proteins into linear monomers, rendering their charge proportional to their length so that migration is a function of size. Abbreviated SDS-polyacrylamide gel electrophoresis or SDS-PAGE" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000122 ! Two Dimensional Polyacrylamide Gel Electrophoresis
 is_a: PRIDE:0000568 ! 2D PAGE
 
@@ -788,138 +788,138 @@ is_a: PRIDE:0000568 ! 2D PAGE
 [Term]
 id: PRIDE:0000125
 name: pH low value
-def: "The lowest pH of an immobilised pH gradient gel." [PRIDE:PRIDE]
+def: "The lowest pH of an immobilised pH gradient gel" [PRIDE:PRIDE]
 is_a: PRIDE:0000123 ! Immobilized pH Gradient Electrophoresis
 
 [Term]
 id: PRIDE:0000126
 name: pH high value
-def: "The highest pH of an immobilised pH gradient gel." [PRIDE:PRIDE]
+def: "The highest pH of an immobilised pH gradient gel" [PRIDE:PRIDE]
 is_a: PRIDE:0000123 ! Immobilized pH Gradient Electrophoresis
 
 [Term]
 id: PRIDE:0000127
 name: IPG strip length cm
-def: "The length in centimeters of an immobilised pH gradient gel." [PRIDE:PRIDE]
+def: "The length in centimeters of an immobilised pH gradient gel" [PRIDE:PRIDE]
 comment: This value associated with this CV term should always be in centimeters.
 is_a: PRIDE:0000123 ! Immobilized pH Gradient Electrophoresis
 
 [Term]
 id: PRIDE:0000128
 name: First dimension details
-def: "Details of immobilised pH gradient gel electrophoresis which exclude the pH range of the gel and strip length parameters." [PRIDE:PRIDE]
+def: "Details of immobilised pH gradient gel electrophoresis which exclude the pH range of the gel and strip length parameters" [PRIDE:PRIDE]
 comment: This CV term should be used in association with a value that is a free-text description of the first dimension details
 relationship: part_of PRIDE:0000123 ! Immobilized pH Gradient Electrophoresis
 
 [Term]
 id: PRIDE:0000129
 name: Second dimension details
-def: "Details of sodium dodecyl sulfate polyacrylamide gel electrophoresis." [PRIDE:PRIDE]
+def: "Details of sodium dodecyl sulfate polyacrylamide gel electrophoresis" [PRIDE:PRIDE]
 comment: This CV term should be used in association with a value that is a free-text description of the second dimension details
 is_a: PRIDE:0000124 ! Sodium dodecyl sulfate polyacrylamide gel electrophoresis
 
 [Term]
 id: PRIDE:0000130
 name: Obsoleted parameters
-def: "Obsoleted terms." [Curator:Rc]
+def: "Obsoleted terms" [Curator:Rc]
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000131
 name: Spot normalized volume
-def: "A value for spot volume which is standardized across gels and is derived from the individual gel spot volume values." [PRIDE:PRIDE]
+def: "A value for spot volume which is standardized across gels and is derived from the individual gel spot volume values" [PRIDE:PRIDE]
 is_a: PRIDE:0000107 ! Gel spot parameter
 
 [Term]
 id: PRIDE:0000132
 name: Spot normalized volume method
-def: "The method by which the normalized value for spot volume is derived from the individual gel spot volume values." [PRIDE:PRIDE]
+def: "The method by which the normalized value for spot volume is derived from the individual gel spot volume values" [PRIDE:PRIDE]
 is_a: PRIDE:0000107 ! Gel spot parameter
 
 [Term]
 id: PRIDE:0000133
 name: Isobaric residue K/Q
-def: "The amino acids glutamine (Q) (mol wt = 146) cannot be distinguished from lysine (K) (mol wt = 146)." [PRIDE:PRIDE]
+def: "The amino acids glutamine (Q) (mol wt = 146) cannot be distinguished from lysine (K) (mol wt = 146)" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000134
 name: Anticoagulant
-def: "A substance that prevents coagulation; that is, it stops blood from clotting." [PRIDE:PRIDE]
+def: "A substance that prevents coagulation; that is, it stops blood from clotting" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
 id: PRIDE:0000135
 name: Mapping date
-def: "Date of last mapping of given identifier to current UniProt accession number." [PRIDE:PRIDE]
+def: "Date of last mapping of given identifier to current UniProt accession number" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000136
 name: Mapping status
-def: "Status of last mapping of given identifier to current UniProt accession number. Valid values are 'mappingAllOK', 'not mapped peptide mismatch', 'not mapped accession not found' and 'not mapped taxon not found' ." [PRIDE:PRIDE]
+def: "Status of last mapping of given identifier to current UniProt accession number. Valid values are 'mappingAllOK', 'not mapped peptide mismatch', 'not mapped accession not found' and 'not mapped taxon not found' " [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000137
 name: Mapping history
-def: "Status of last mapping of given identifier to current UniProt accession number. Valid values are 'unchanged since last mapping', 'changed accession' and 'changed version of accession' ." [PRIDE:PRIDE]
+def: "Status of last mapping of given identifier to current UniProt accession number. Valid values are 'unchanged since last mapping', 'changed accession' and 'changed version of accession' " [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000138
 name: Discriminant score
-def: "PeptideProphet discriminant score fval." [PRIDE:PRIDE]
+def: "PeptideProphet discriminant score fval" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000101 ! PeptideProphet
 
 [Term]
 id: PRIDE:0000139
 name: Not Mapped SOAP Error
-def: "Error message: SOAP protocol failed." [PRIDE:PRIDE]
+def: "Error message: SOAP protocol failed" [PRIDE:PRIDE]
 is_a: PRIDE:0000136 ! Mapping status
 
 [Term]
 id: PRIDE:0000140
 name: Not Mapped Database Error
-def: "Error message: Error with queried database." [PRIDE:PRIDE]
+def: "Error message: Error with queried database" [PRIDE:PRIDE]
 is_a: PRIDE:0000136 ! Mapping status
 
 [Term]
 id: PRIDE:0000141
 name: Not Mapped No Mapping Found
-def: "Error message: Unable to match given identifier." [PRIDE:PRIDE]
+def: "Error message: Unable to match given identifier" [PRIDE:PRIDE]
 is_a: PRIDE:0000136 ! Mapping status
 
 [Term]
 id: PRIDE:0000142
 name: Not Mapped Peptide Mismatch
-def: "Error message: One or more peptide sequences did not match query sequence." [PRIDE:PRIDE]
+def: "Error message: One or more peptide sequences did not match query sequence" [PRIDE:PRIDE]
 is_a: PRIDE:0000136 ! Mapping status
 
 [Term]
 id: PRIDE:0000143
 name: Mapped Taxon Not Found
-def: "Error message: No mapping to proteins from defined taxon." [PRIDE:PRIDE]
+def: "Error message: No mapping to proteins from defined taxon" [PRIDE:PRIDE]
 is_a: PRIDE:0000136 ! Mapping status
 
 [Term]
 id: PRIDE:0000144
 name: Mapped All Ok
-def: "Sucessful completion of operation message." [PRIDE:PRIDE]
+def: "Sucessful completion of operation message" [PRIDE:PRIDE]
 is_a: PRIDE:0000136 ! Mapping status
 
 [Term]
 id: PRIDE:0000145
 name: PepSplice
-def: "The PepSplice algorithm." [PRIDE:PRIDE]
+def: "The PepSplice algorithm" [PRIDE:PRIDE]
 is_a: PRIDE:0000044 ! Search algorithm
 is_a: PRIDE:0000573 ! Identification software
 
 [Term]
 id: PRIDE:0000146
 name: PepSplice precision
-def: "PepSplice precision refers to the accuracy of peptide-spectrum matches (PSMs) produced by the PepSplice search engine, a specialized tool used for the identification of peptides, particularly for novel or unexpected peptide sequences. Precision is a key metric used to assess the quality and reliability of search results in proteomics." [PRIDE:PRIDE]
+def: "PepSplice precision refers to the accuracy of peptide-spectrum matches (PSMs) produced by the PepSplice search engine, a specialized tool used for the identification of peptides, particularly for novel or unexpected peptide sequences. Precision is a key metric used to assess the quality and reliability of search results in proteomics" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000145 ! PepSplice
 is_a: PRIDE:0000145 ! PepSplice
 
@@ -933,68 +933,68 @@ is_a: PRIDE:0000145 ! PepSplice
 [Term]
 id: PRIDE:0000148
 name: PepSplice P-value
-def: "A Score based on the hypergeometric model." [PRIDE:PRIDE]
+def: "A Score based on the hypergeometric model" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000145 ! PepSplice
 is_a: PRIDE:0000145 ! PepSplice
 
 [Term]
 id: PRIDE:0000149
 name: PepSplice Deltascore
-def: "The Difference between the pvalues of the 1st and the 2nd best peptide; if two peptides have the same pvalue, they are taken together." [PRIDE:PRIDE]
+def: "The Difference between the pvalues of the 1st and the 2nd best peptide; if two peptides have the same pvalue, they are taken together" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000145 ! PepSplice
 is_a: PRIDE:0000145 ! PepSplice
 
 [Term]
 id: PRIDE:0000150
 name: PepSplice Score Count
-def: "The score count." [PRIDE:PRIDE]
+def: "The score count" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000145 ! PepSplice
 is_a: PRIDE:0000145 ! PepSplice
 
 [Term]
 id: PRIDE:0000151
 name: PepSplice Penalty
-def: "The Sum of all penalties for the peptide assignment." [PRIDE:PRIDE]
+def: "The Sum of all penalties for the peptide assignment" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000145 ! PepSplice
 is_a: PRIDE:0000145 ! PepSplice
 
 [Term]
 id: PRIDE:0000152
 name: PepSplice Read Direction
-def: "The reading direction on the DNA." [PRIDE:PRIDE]
+def: "The reading direction on the DNA" [PRIDE:PRIDE]
 relationship: part_of PRIDE:0000145 ! PepSplice
 is_a: PRIDE:0000145 ! PepSplice
 
 [Term]
 id: PRIDE:0000153
 name: PepSplice Forward Read Direction
-def: "The reading direction on the DNA is 5' to 3'." [PRIDE:PRIDE]
+def: "The reading direction on the DNA is 5' to 3'" [PRIDE:PRIDE]
 is_a: PRIDE:0000152 ! PepSplice Read Direction
 
 [Term]
 id: PRIDE:0000154
 name: PepSplice Reverse Read Direction
-def: "The reading direction on the DNA 3' to 5'." [PRIDE:PRIDE]
+def: "The reading direction on the DNA 3' to 5'" [PRIDE:PRIDE]
 is_a: PRIDE:0000152 ! PepSplice Read Direction
 is_a: PRIDE:0000145 ! PepSplice
 
 [Term]
 id: PRIDE:0000155
 name: Unmappable
-def: "unsucessful mapping." [PRIDE:PRIDE]
+def: "unsucessful mapping" [PRIDE:PRIDE]
 is_a: PRIDE:0000136 ! Mapping status
 
 [Term]
 id: PRIDE:0000156
 name: Project identifier
-def: "unique identifier of project." [PRIDE:PRIDE]
+def: "unique identifier of project" [PRIDE:PRIDE]
 synonym: "Project ID" EXACT [NCIT:C165055]
 relationship: part_of PRIDE:0000097 ! Project
 
 [Term]
 id: PRIDE:0000157
 name: Search type
-def: "type of search." [PRIDE:PRIDE]
+def: "type of search" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
@@ -1006,61 +1006,61 @@ is_a: PRIDE:0000157 ! Search type
 [Term]
 id: PRIDE:0000159
 name: MS/MS search
-def: "MS/MS Search refers to the process of identifying molecules (typically proteins, peptides, metabolites, or small molecules) using tandem mass spectrometry (MS/MS) data. Unlike simple mass spectrometry (MS1), MS/MS involves fragmenting precursor ions into smaller product ions, generating a detailed fragmentation pattern or spectra that can be used to identify the structure or sequence of the molecule." [PRIDE:PRIDE]
+def: "MS/MS Search refers to the process of identifying molecules (typically proteins, peptides, metabolites, or small molecules) using tandem mass spectrometry (MS/MS) data. Unlike simple mass spectrometry (MS1), MS/MS involves fragmenting precursor ions into smaller product ions, generating a detailed fragmentation pattern or spectra that can be used to identify the structure or sequence of the molecule" [PRIDE:PRIDE]
 is_a: PRIDE:0000157 ! Search type
 
 [Term]
 id: PRIDE:0000160
 name: Enzyme
-def: "type of enzyme used to fragment the protein. The value will equal the name of the enxzyme used e.g. ." [PRIDE:PRIDE]
+def: "type of enzyme used to fragment the protein. The value will equal the name of the enxzyme used e.g. " [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000161
 name: Fragment mass tolerance setting
-def: "range of acceptable fragment masses accepted by instrument." [PRIDE:PRIDE]
+def: "range of acceptable fragment masses accepted by instrument" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000162
 name: Allowed missed cleavages
-def: "number of missed cleavage sites taken into account." [PRIDE:PRIDE]
+def: "number of missed cleavage sites taken into account" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000163
 name: Instrument type
-def: "name of instrument used in analysis." [PRIDE:PRIDE]
+def: "name of instrument used in analysis" [PRIDE:PRIDE]
 is_a: PRIDE:0000071 ! Search engine setting
 
 [Term]
 id: PRIDE:0000164
 name: Mapped Without Supporting Peptides
-def: "Sucessful mapping without supporting evidence from peptides." [PRIDE:PRIDE]
+def: "Sucessful mapping without supporting evidence from peptides" [PRIDE:PRIDE]
 is_a: PRIDE:0000136 ! Mapping status
 
 [Term]
 id: PRIDE:0000165
 name: Automatic allocation
-def: "PICR tool has allocated the accession number." [PRIDE:PRIDE]
+def: "PICR tool has allocated the accession number" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000166
 name: Ambiguous modification
-def: "Modification with a MonoDeltaMass, which can not unambiguously be  assigned to only one modification and for which several possibilities exist." [PRIDE:PRIDE]
+def: "Modification with a MonoDeltaMass, which can not unambiguously be  assigned to only one modification and for which several possibilities exist" [PRIDE:PRIDE]
 is_a: PRIDE:0000002 ! ModificationItem additional parameter
 
 [Term]
 id: PRIDE:0000167
 name: Novel locus information
-def: "Detailed information about a genomic locus identified by whole genome searches." [PRIDE:PRIDE]
+def: "Detailed information about a genomic locus identified by whole genome searches" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000168
 name: Nucleic acid sequence
-def: "A nucleic acid sequence refers to the linear arrangement of nucleotides (the basic building blocks of DNA and RNA) in a specific order." [PRIDE:PRIDE]
+def: "A nucleic acid sequence refers to the linear arrangement of nucleotides (the basic building blocks of DNA and RNA) in a specific order" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_a: PRIDE:0000004 ! Identification additional parameter
 
@@ -1074,7 +1074,7 @@ is_a: PRIDE:0000004 ! Identification additional parameter
 [Term]
 id: PRIDE:0000170
 name: Stop position of the nucleic acid sequence on the chromosome
-def: "The stop position of a nucleic acid sequence on a chromosome refers to the ending coordinate where the sequence finishes on the chromosome." [PRIDE:PRIDE]
+def: "The stop position of a nucleic acid sequence on a chromosome refers to the ending coordinate where the sequence finishes on the chromosome" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_a: PRIDE:0000004 ! Identification additional parameter
 
@@ -1087,19 +1087,19 @@ is_a: PRIDE:0000000 ! Reference additional parameter
 [Term]
 id: PRIDE:0000172
 name: Search database protein sequence length
-def: "Value of average of all individual peptide identifications for this protein." [PRIDE:PRIDE]
+def: "Value of average of all individual peptide identifications for this protein" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000173
 name: MeanOfPeptideScores
-def: "Value of average of all individual peptide scores." [PRIDE:PRIDE]
+def: "Value of average of all individual peptide scores" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000174
 name: Isoelectric point
-def: "Isoelectric point of a protein." [PRIDE:PRIDE]
+def: "Isoelectric point of a protein" [PRIDE:PRIDE]
 synonym: "pI" EXACT []
 is_a: PRIDE:0000008 ! Protein search engine output parameter
 relationship: part_of PRIDE:0000056 ! Bioworks
@@ -1107,163 +1107,163 @@ relationship: part_of PRIDE:0000056 ! Bioworks
 [Term]
 id: PRIDE:0000175
 name: XML generation software
-def: "The software which was used to generate the PRIDE XML file." [PRIDE:PRIDE]
+def: "The software which was used to generate the PRIDE XML file" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000176
 name: X\!Tandem Hyperscore
-def: "The X!Tandem hyperscore for the peptide." [PRIDE:PRIDE]
+def: "The X!Tandem hyperscore for the peptide" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 
 [Term]
 id: PRIDE:0000177
 name: Spectrum Mill peptide score
-def: "The Spectrum Mill score for the peptide." [PRIDE:PRIDE]
+def: "The Spectrum Mill score for the peptide" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 
 [Term]
 id: PRIDE:0000178
 name: Peptide selection
-def: "A protocol step to select for a particular type of peptides." [PRIDE:PRIDE]
+def: "A protocol step to select for a particular type of peptides" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
 id: PRIDE:0000179
 name: dotproduct
-def: "X|Tandem dot product score." [PRIDE:PRIDE]
+def: "X|Tandem dot product score" [PRIDE:PRIDE]
 is_a: PRIDE:0000047 ! X|Tandem
 
 [Term]
 id: PRIDE:0000180
 name: delta
-def: "X|Tandem delta score." [PRIDE:PRIDE]
+def: "X|Tandem delta score" [PRIDE:PRIDE]
 is_a: PRIDE:0000047 ! X|Tandem
 
 [Term]
 id: PRIDE:0000181
 name: deltastar
-def: "X|Tandem delta star score." [PRIDE:PRIDE]
+def: "X|Tandem delta star score" [PRIDE:PRIDE]
 is_a: PRIDE:0000047 ! X|Tandem
 
 [Term]
 id: PRIDE:0000182
 name: zscore
-def: "X|Tandem Z score." [PRIDE:PRIDE]
+def: "X|Tandem Z score" [PRIDE:PRIDE]
 is_a: PRIDE:0000047 ! X|Tandem
 
 [Term]
 id: PRIDE:0000183
 name: expect
-def: "X|Tandem expectancy score." [PRIDE:PRIDE]
+def: "X|Tandem expectancy score" [PRIDE:PRIDE]
 is_a: PRIDE:0000047 ! X|Tandem
 
 [Term]
 id: PRIDE:0000184
 name: Query number
-def: "Search parameter that allows users to find query results from old data." [PRIDE:PRIDE]
+def: "Search parameter that allows users to find query results from old data" [PRIDE:PRIDE]
 is_a: PRIDE:0000046 ! Mascot
 
 [Term]
 id: PRIDE:0000185
 name: OMSSA E-value
-def: "E-value parameter from OMSSA." [PRIDE:PRIDE]
+def: "E-value parameter from OMSSA" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 
 [Term]
 id: PRIDE:0000186
 name: OMSSA P-value
-def: "P-value parameter from OMSSA." [PRIDE:PRIDE]
+def: "P-value parameter from OMSSA" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 
 [Term]
 id: PRIDE:0000187
 name: Fragment Ion Annotation
-def: "Fragment ion annotation of the peptide." [PRIDE:PRIDE]
+def: "Fragment ion annotation of the peptide" [PRIDE:PRIDE]
 synonym: "product ion property" EXACT []
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000188
 name: product ion m/z
-def: "Mass." [PRIDE:PRIDE]
+def: "Mass" [PRIDE:PRIDE]
 synonym: "fragment ion mass" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000189
 name: product ion intensity
-def: "Intensity." [PRIDE:PRIDE]
+def: "Intensity" [PRIDE:PRIDE]
 synonym: "fragment ion intensity" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000190
 name: product ion mass error
-def: "Mass error." [PRIDE:PRIDE]
+def: "Mass error" [PRIDE:PRIDE]
 synonym: "fragment ion mass error" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000191
 name: product ion retention time error
-def: "Retention time error in minutes." [PRIDE:PRIDE]
+def: "Retention time error in minutes" [PRIDE:PRIDE]
 synonym: "fragment ion retention time error" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000192
 name: product ion type
-def: "Product ion type." [PRIDE:PRIDE]
+def: "Product ion type" [PRIDE:PRIDE]
 synonym: "fragment ion type" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000193
 name: y ion
-def: "Y ion type." [PRIDE:PRIDE]
+def: "Y ion type" [PRIDE:PRIDE]
 synonym: "y fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000194
 name: b ion
-def: "B ion type." [PRIDE:PRIDE]
+def: "B ion type" [PRIDE:PRIDE]
 synonym: "b fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000195
 name: b ion -NH3
-def: "B ion type with a neutral loss of an ammonia group." [PRIDE:PRIDE]
+def: "B ion type with a neutral loss of an ammonia group" [PRIDE:PRIDE]
 synonym: "b fragment ion -NH3" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
 id: PRIDE:0000196
 name: b ion -H2O
-def: "B ion type with a neutral loss of a water molecule." [PRIDE:PRIDE]
+def: "B ion type with a neutral loss of a water molecule" [PRIDE:PRIDE]
 synonym: "b fragment ion -H2O" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
 id: PRIDE:0000197
 name: y ion -H2O
-def: "Y ion type with the neutral loss of a molecule water." [PRIDE:PRIDE]
+def: "Y ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
 synonym: "y fragment ion -H2O" EXACT []
 is_a: PRIDE:0000193 ! y ion
 
 [Term]
 id: PRIDE:0000198
 name: y ion -NH3
-def: "Y ion type with the neutral loss of an ammonia group." [PRIDE:PRIDE]
+def: "Y ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
 synonym: "y fragment ion -NH3" EXACT []
 is_a: PRIDE:0000193 ! y ion
 
 [Term]
 id: PRIDE:0000199
 name: in source ion
-def: "Ion resulting from in-source fragmentation." [PRIDE:PRIDE]
+def: "Ion resulting from in-source fragmentation" [PRIDE:PRIDE]
 synonym: "in source fragment ion" EXACT []
 synonym: "in-source ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
@@ -1271,408 +1271,408 @@ is_a: PRIDE:0000192 ! product ion type
 [Term]
 id: PRIDE:0000200
 name: non-identified ion
-def: "Fragment ion that could not be assigned to a predicted fragment ion mass." [PRIDE:PRIDE]
+def: "Fragment ion that could not be assigned to a predicted fragment ion mass" [PRIDE:PRIDE]
 synonym: "unidentified ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000201
 name: co-eluting ion
-def: "Fragment ion that was matched to another, co-eluting peptide precursor." [PRIDE:PRIDE]
+def: "Fragment ion that was matched to another, co-eluting peptide precursor" [PRIDE:PRIDE]
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000202
 name: Parent Ion Annotation
-def: "Parent ion annotation of the peptide." [PRIDE:PRIDE]
+def: "Parent ion annotation of the peptide" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000203
 name: parent ion retention time
-def: "Retention time in minutes." [PRIDE:PRIDE]
+def: "Retention time in minutes" [PRIDE:PRIDE]
 is_a: PRIDE:0000202 ! Parent Ion Annotation
 
 [Term]
 id: PRIDE:0000204
 name: product ion charge
-def: "Charge state." [PRIDE:PRIDE]
+def: "Charge state" [PRIDE:PRIDE]
 synonym: "fragment ion charge" EXACT []
 is_a: PRIDE:0000187 ! Fragment Ion Annotation
 
 [Term]
 id: PRIDE:0000205
 name: Heavy stable isotope label
-def: "A general term for any stable isotope method." [PRIDE:PRIDE]
+def: "A general term for any stable isotope method" [PRIDE:PRIDE]
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000206
 name: Heavy stable isotope label residue
-def: "The precise amino acid that has been modified." [PRIDE:PRIDE]
+def: "The precise amino acid that has been modified" [PRIDE:PRIDE]
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000207
 name: Light stable isotope label
-def: "A general term for any stable isotope method." [PRIDE:PRIDE]
+def: "A general term for any stable isotope method" [PRIDE:PRIDE]
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000208
 name: Light stable isotope label residue
-def: "The precise amino acid that has been modified." [PRIDE:PRIDE]
+def: "The precise amino acid that has been modified" [PRIDE:PRIDE]
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000209
 name: Peptide pair id
-def: "Facilitate mapping between peptide pairs (usually heavy/light) to which the stable isotope ratio below relates." [PRIDE:PRIDE]
+def: "Facilitate mapping between peptide pairs (usually heavy/light) to which the stable isotope ratio below relates" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000210
 name: Stable isotope ratio
-def: "Ratio of peptide pair the sequence/sample is the numerator in the ratio." [PRIDE:PRIDE]
+def: "Ratio of peptide pair the sequence/sample is the numerator in the ratio" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000211
 name: Quantitative sample reference
-def: "This links back to the value given to the heavy/light stable isotope label to relate the peptide ratio back to the sample." [PRIDE:PRIDE]
+def: "This links back to the value given to the heavy/light stable isotope label to relate the peptide ratio back to the sample" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000212
 name: Mascot expect value
-def: "Expect value as defined for the Mascot search algorithm." [PRIDE:PRIDE]
+def: "Expect value as defined for the Mascot search algorithm" [PRIDE:PRIDE]
 is_a: PRIDE:0000046 ! Mascot
 
 [Term]
 id: PRIDE:0000213
 name: Inspect
-def: "The Inspect search algorithm." [PRIDE:PRIDE]
+def: "The Inspect search algorithm" [PRIDE:PRIDE]
 is_a: PRIDE:0000044 ! Search algorithm
 is_a: PRIDE:0000573 ! Identification software
 
 [Term]
 id: PRIDE:0000214
 name: Inspect MQScore
-def: "Quality score of a match." [PRIDE:PRIDE]
+def: "Quality score of a match" [PRIDE:PRIDE]
 is_a: PRIDE:0000213 ! Inspect
 
 [Term]
 id: PRIDE:0000215
 name: Inspect p-value
-def: "Probability that the top match is correct." [PRIDE:PRIDE]
+def: "Probability that the top match is correct" [PRIDE:PRIDE]
 is_a: PRIDE:0000213 ! Inspect
 
 [Term]
 id: PRIDE:0000216
 name: ProteomExchange project accession number
-def: "ProteomExchange accession number of the project where the PRIDE experiment is included." [PRIDE:PRIDE]
+def: "ProteomExchange accession number of the project where the PRIDE experiment is included" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000217
 name: ProteomExchange project hash
-def: "Hash in Tranche of the whole ProteomExchange project where the PRIDE experiment is included." [PRIDE:PRIDE]
+def: "Hash in Tranche of the whole ProteomExchange project where the PRIDE experiment is included" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000218
 name: Original MS data file format
-def: "Original format of the file containing MS data." [PRIDE:PRIDE]
+def: "Original format of the file containing MS data" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000219
 name: Date of search
-def: "Date when the search was performed." [PRIDE:PRIDE]
+def: "Date when the search was performed" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000220
 name: Calculated Mass To Charge Ratio
-def: "m/z value converted from the MH+ value, according to this formula: CalculatedMZ = (precursorMH+ - HYDROGEN_MASS + (precursorCharge * HYDROGEN_MASS))/ precursorCharge." [PRIDE:PRIDE]
+def: "m/z value converted from the MH+ value, according to this formula: CalculatedMZ = (precursorMH+ - HYDROGEN_MASS + (precursorCharge * HYDROGEN_MASS))/ precursorCharge" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000221
 name: parent ion retention time error
-def: "Retention time error in minutes." [PRIDE:PRIDE]
+def: "Retention time error in minutes" [PRIDE:PRIDE]
 is_a: PRIDE:0000202 ! Parent Ion Annotation
 
 [Term]
 id: PRIDE:0000222
 name: spectrum iTRAQ ratio
-def: "average iTRAQ ratio sample over control." [PRIDE:PRIDE]
+def: "average iTRAQ ratio sample over control" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000223
 name: peptide iTRAQ ratio average
-def: "Average spectrum iTRAQ ratio (=geometric mean) for the peptide." [PRIDE:PRIDE]
+def: "Average spectrum iTRAQ ratio (=geometric mean) for the peptide" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000224
 name: protein iTRAQ ratio average
-def: "Average spectrum iTRAQ ratio (=geometric mean) for the protein." [PRIDE:PRIDE]
+def: "Average spectrum iTRAQ ratio (=geometric mean) for the protein" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000225
 name: protein iTRAQ ratio number of contributing spectra
-def: "Number of quantified spectra contributing to the protein iTRAQ ratio." [PRIDE:PRIDE]
+def: "Number of quantified spectra contributing to the protein iTRAQ ratio" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000226
 name: protein iTRAQ ratio standard deviation
-def: "Geometric sample standard deviation of the protein iTRAQ ratio." [PRIDE:PRIDE]
+def: "Geometric sample standard deviation of the protein iTRAQ ratio" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000227
 name: x ion
-def: "X ion type." [PRIDE:PRIDE]
+def: "X ion type" [PRIDE:PRIDE]
 synonym: "x fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000228
 name: x ion -H2O
-def: "X ion type with the neutral loss of a molecule water." [PRIDE:PRIDE]
+def: "X ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
 synonym: "x fragment ion -H2O" EXACT []
 is_a: PRIDE:0000227 ! x ion
 
 [Term]
 id: PRIDE:0000229
 name: x ion -NH3
-def: "X ion type with the neutral loss of an ammonia group." [PRIDE:PRIDE]
+def: "X ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
 synonym: "x fragment ion -NH3" EXACT []
 is_a: PRIDE:0000227 ! x ion
 
 [Term]
 id: PRIDE:0000230
 name: z ion
-def: "Z ion type." [PRIDE:PRIDE]
+def: "Z ion type" [PRIDE:PRIDE]
 synonym: "z fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000231
 name: z ion -H2O
-def: "Z ion type with the neutral loss of a molecule water." [PRIDE:PRIDE]
+def: "Z ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
 synonym: "z fragment ion -H2O" EXACT []
 is_a: PRIDE:0000230 ! z ion
 
 [Term]
 id: PRIDE:0000232
 name: z ion -NH3
-def: "Z ion type with the neutral loss of an ammonia group." [PRIDE:PRIDE]
+def: "Z ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
 synonym: "z fragment ion -NH3" EXACT []
 is_a: PRIDE:0000230 ! z ion
 
 [Term]
 id: PRIDE:0000233
 name: a ion
-def: "A ion type." [PRIDE:PRIDE]
+def: "A ion type" [PRIDE:PRIDE]
 synonym: "a fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000234
 name: a ion -H2O
-def: "A ion type with the neutral loss of a molecule water." [PRIDE:PRIDE]
+def: "A ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
 synonym: "a fragment ion -H2O" EXACT []
 is_a: PRIDE:0000233 ! a ion
 
 [Term]
 id: PRIDE:0000235
 name: a ion -NH3
-def: "A ion type with the neutral loss of an ammonia group." [PRIDE:PRIDE]
+def: "A ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
 synonym: "a fragment ion -NH3" EXACT []
 is_a: PRIDE:0000233 ! a ion
 
 [Term]
 id: PRIDE:0000236
 name: c ion
-def: "C ion type." [PRIDE:PRIDE]
+def: "C ion type" [PRIDE:PRIDE]
 synonym: "c fragment ion" EXACT []
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000237
 name: c ion -H2O
-def: "C ion type with the neutral loss of a molecule water." [PRIDE:PRIDE]
+def: "C ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
 synonym: "c fragment ion -H2O" EXACT []
 is_a: PRIDE:0000236 ! c ion
 
 [Term]
 id: PRIDE:0000238
 name: c ion -NH3
-def: "C ion type with the neutral loss of an ammonia group." [PRIDE:PRIDE]
+def: "C ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
 synonym: "c fragment ion -NH3" EXACT []
 is_a: PRIDE:0000236 ! c ion
 
 [Term]
 id: PRIDE:0000239
 name: immonium ion
-def: "Immonium ion type." [PRIDE:PRIDE]
+def: "Immonium ion type" [PRIDE:PRIDE]
 is_a: PRIDE:0000192 ! product ion type
 
 [Term]
 id: PRIDE:0000240
 name: immonium A
-def: "Immonium ion type for alanine." [PRIDE:PRIDE]
+def: "Immonium ion type for alanine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000241
 name: immonium C
-def: "Immonium ion type for cysteine." [PRIDE:PRIDE]
+def: "Immonium ion type for cysteine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000242
 name: immonium D
-def: "Immonium ion type for aspartic acid." [PRIDE:PRIDE]
+def: "Immonium ion type for aspartic acid" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000243
 name: immonium E
-def: "Immonium ion type for glutamic acid." [PRIDE:PRIDE]
+def: "Immonium ion type for glutamic acid" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000244
 name: immonium F
-def: "Immonium ion type for phenylalanine." [PRIDE:PRIDE]
+def: "Immonium ion type for phenylalanine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000245
 name: immonium G
-def: "Immonium ion type for glycine." [PRIDE:PRIDE]
+def: "Immonium ion type for glycine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000246
 name: immonium H
-def: "Immonium ion type for histidine." [PRIDE:PRIDE]
+def: "Immonium ion type for histidine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000247
 name: immonium I
-def: "Immonium ion type for isoleucine." [PRIDE:PRIDE]
+def: "Immonium ion type for isoleucine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000248
 name: immonium K
-def: "Immonium ion type for lysine." [PRIDE:PRIDE]
+def: "Immonium ion type for lysine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000249
 name: immonium L
-def: "Immonium ion type for leucine." [PRIDE:PRIDE]
+def: "Immonium ion type for leucine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000250
 name: immonium M
-def: "Immonium ion type for methionine." [PRIDE:PRIDE]
+def: "Immonium ion type for methionine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000251
 name: immonium N
-def: "Immonium ion type for asparagine." [PRIDE:PRIDE]
+def: "Immonium ion type for asparagine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000252
 name: immonium P
-def: "Immonium ion type for proline." [PRIDE:PRIDE]
+def: "Immonium ion type for proline" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000253
 name: immonium Q
-def: "Immonium ion type for glutamine." [PRIDE:PRIDE]
+def: "Immonium ion type for glutamine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000254
 name: immonium R
-def: "Immonium ion type for arginine." [PRIDE:PRIDE]
+def: "Immonium ion type for arginine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000255
 name: immonium S
-def: "Immonium ion type for serine." [PRIDE:PRIDE]
+def: "Immonium ion type for serine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000256
 name: immonium T
-def: "Immonium ion type for threnine." [PRIDE:PRIDE]
+def: "Immonium ion type for threnine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000257
 name: immonium V
-def: "Immonium ion type for valine." [PRIDE:PRIDE]
+def: "Immonium ion type for valine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000258
 name: immonium W
-def: "Immonium ion type for tryptophan." [PRIDE:PRIDE]
+def: "Immonium ion type for tryptophan" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000259
 name: immonium Y
-def: "Immonium ion type for tyrosine." [PRIDE:PRIDE]
+def: "Immonium ion type for tyrosine" [PRIDE:PRIDE]
 is_a: PRIDE:0000239 ! immonium ion
 
 [Term]
 id: PRIDE:0000260
 name: precursor ion type
-def: "precursor ion type." [PRIDE:PRIDE]
+def: "precursor ion type" [PRIDE:PRIDE]
 synonym: "parent ion type" EXACT []
 is_a: PRIDE:0000202 ! Parent Ion Annotation
 
 [Term]
 id: PRIDE:0000261
 name: precursor ion -H2O
-def: "Precursor ion type with the neutral loss of a molecule water." [PRIDE:PRIDE]
+def: "Precursor ion type with the neutral loss of a molecule water" [PRIDE:PRIDE]
 synonym: "parent ion -H2O" EXACT []
 is_a: PRIDE:0000263 ! precursor ion
 
 [Term]
 id: PRIDE:0000262
 name: precursor ion -NH3
-def: "Precursor ion type with the neutral loss of an ammonia group." [PRIDE:PRIDE]
+def: "Precursor ion type with the neutral loss of an ammonia group" [PRIDE:PRIDE]
 synonym: "parent ion -NH3" EXACT []
 is_a: PRIDE:0000263 ! precursor ion
 
 [Term]
 id: PRIDE:0000263
 name: precursor ion
-def: "Precursor ion." [PRIDE:PRIDE]
+def: "Precursor ion" [PRIDE:PRIDE]
 synonym: "parent ion" EXACT []
 is_a: PRIDE:0000260 ! precursor ion type
 
@@ -1731,19 +1731,19 @@ is_a: PRIDE:0000004 ! Identification additional parameter
 [Term]
 id: PRIDE:0000272
 name: Project secondary name
-def: "Allows experiments inside the same project to be grouped or organised as subprojects. This will not be displayed in the PRIDE web page." [PRIDE:PRIDE]
+def: "Allows experiments inside the same project to be grouped or organised as subprojects. This will not be displayed in the PRIDE web page" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000273
 name: SloMo score threshold for valid modification location
-def: "The SloMo score threshold for a valid modification location is a statistical cutoff used in mass spectrometry (MS/MS) to determine the confidence that a specific position within a peptide or protein is modified." [PRIDE:PRIDE]
+def: "The SloMo score threshold for a valid modification location is a statistical cutoff used in mass spectrometry (MS/MS) to determine the confidence that a specific position within a peptide or protein is modified" [PRIDE:PRIDE]
 is_a: PRIDE:0000044 ! Search algorithm
 
 [Term]
 id: PRIDE:0000274
 name: MaxQuant percentage threshold for valid modification location
-def: "In MaxQuant, the percentage threshold for a valid modification location is typically based on the site probability for post-translational modification (PTM) localization. This probability indicates the confidence that a particular amino acid (residue) within a peptide is modified." [PRIDE:PRIDE]
+def: "In MaxQuant, the percentage threshold for a valid modification location is typically based on the site probability for post-translational modification (PTM) localization. This probability indicates the confidence that a particular amino acid (residue) within a peptide is modified" [PRIDE:PRIDE]
 is_a: PRIDE:0000044 ! Search algorithm
 
 [Term]
@@ -1761,18 +1761,18 @@ is_a: PRIDE:0000044 ! Search algorithm
 [Term]
 id: PRIDE:0000277
 name: Valid location
-def: "a valid location refers to a site on a peptide or protein sequence that has been confidently identified as being modified." [PRIDE:PRIDE]
+def: "a valid location refers to a site on a peptide or protein sequence that has been confidently identified as being modified" [PRIDE:PRIDE]
 is_a: PRIDE:0000002 ! ModificationItem additional parameter
 
 [Term]
 id: PRIDE:0000278
 name: Processing method additional parameter
-def: "a processing method refers to the specific steps or algorithms used to analyze raw MS data, identify peptides, and assign modifications. These processing methods often come with additional parameters that allow users to customize the analysis based on their experimental needs." [PRIDE:PRIDE]
+def: "a processing method refers to the specific steps or algorithms used to analyze raw MS data, identify peptides, and assign modifications. These processing methods often come with additional parameters that allow users to customize the analysis based on their experimental needs" [PRIDE:PRIDE]
 
 [Term]
 id: PRIDE:0000279
 name: In silico enzyme digestion
-def: "Enzyme that is selected as a parameter of the search engine." [PRIDE:PRIDE]
+def: "Enzyme that is selected as a parameter of the search engine" [PRIDE:PRIDE]
 is_a: PRIDE:0000278 ! Processing method additional parameter
 
 [Term]
@@ -1792,19 +1792,19 @@ is_a: PRIDE:0000230 ! z ion
 [Term]
 id: PRIDE:0000282
 name: Fixed modification
-def: "Fixed type of post-translational modification." [PRIDE:PRIDE]
+def: "Fixed type of post-translational modification" [PRIDE:PRIDE]
 is_a: PRIDE:0000002 ! ModificationItem additional parameter
 
 [Term]
 id: PRIDE:0000283
 name: Variable modification
-def: "Variable type of post-translational modification." [PRIDE:PRIDE]
+def: "Variable type of post-translational modification" [PRIDE:PRIDE]
 is_a: PRIDE:0000002 ! ModificationItem additional parameter
 
 [Term]
 id: PRIDE:0000284
 name: Sf
-def: "The Sf score for each peptide is calculated by a neural network algorithm that incorporates teh Xcorr, DeltaCn, Sp, RSp, peptide mass, charge state, and the number of matched peptides for the search. The protein Sf score is the sum of peptide Sf scores for all the peptides associated with that protein." [PRIDE:PRIDE]
+def: "The Sf score for each peptide is calculated by a neural network algorithm that incorporates teh Xcorr, DeltaCn, Sp, RSp, peptide mass, charge state, and the number of matched peptides for the search. The protein Sf score is the sum of peptide Sf scores for all the peptides associated with that protein" [PRIDE:PRIDE]
 is_a: PRIDE:0000049 ! Peptide search engine output parameter
 relationship: part_of PRIDE:0000045 ! Sequest
 
@@ -1901,44 +1901,44 @@ is_a: PRIDE:0000004 ! Identification additional parameter
 [Term]
 id: PRIDE:0000299
 name: Submitted Protein Accession
-def: "The original submitted protein accession for this identification. This might have been curated as part of the submission process." [PRIDE:PRIDE]
+def: "The original submitted protein accession for this identification. This might have been curated as part of the submission process" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000300
 name: Gel spot identifier
-def: "The gel spot's identifier. This identifier should resemble the one used in, for example, the associated publication." [PRIDE:PRIDE]
+def: "The gel spot's identifier. This identifier should resemble the one used in, for example, the associated publication" [PRIDE:PRIDE]
 is_a: PRIDE:0000107 ! Gel spot parameter
 
 [Term]
 id: PRIDE:0000301
 name: Non-significant protein identification
-def: "Identifies a protein identification that is not significant as defined by the search engine input parameters (for example the set threshold or the set required expect value)." [PRIDE:PRIDE]
+def: "Identifies a protein identification that is not significant as defined by the search engine input parameters (for example the set threshold or the set required expect value)" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000302
 name: Non-significant peptide identification
-def: "Identifies a peptide identification that is not significant as defined by the search engine input parameters (for example the set threshold or the set required expect value)." [PRIDE:PRIDE]
+def: "Identifies a peptide identification that is not significant as defined by the search engine input parameters (for example the set threshold or the set required expect value)" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000303
 name: Decoy hit
-def: "Indicates that this protein identification comes from the used decoy database." [PRIDE:PRIDE]
+def: "Indicates that this protein identification comes from the used decoy database" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 is_obsolete: true
 
 [Term]
 id: PRIDE:0000304
 name: Gel identifier
-def: "The gel's identifier. This identifier should resemble the one used in, for example, the associated publication." [PRIDE:PRIDE]
+def: "The gel's identifier. This identifier should resemble the one used in, for example, the associated publication" [PRIDE:PRIDE]
 is_a: PRIDE:0000107 ! Gel spot parameter
 
 [Term]
 id: PRIDE:0000305
 name: Gel-based experiment
-def: "Defines a gel-based proteomics experiment." [PRIDE:PRIDE]
+def: "Defines a gel-based proteomics experiment" [PRIDE:PRIDE]
 is_a: PRIDE:0000428 ! Bottom-up proteomics
 
 [Term]
@@ -1981,7 +1981,7 @@ is_a: PRIDE:0000309 ! Gel-free quantification method
 [Term]
 id: PRIDE:0000312
 name: Label free
-def: "Describes label free quantification techniques." [PRIDE:PRIDE]
+def: "Describes label free quantification techniques" [PRIDE:PRIDE]
 is_a: PRIDE:0000309 ! Gel-free quantification method
 
 [Term]
@@ -2007,59 +2007,59 @@ is_a: PRIDE:0000316 ! MS1 based isotope labeling
 [Term]
 id: PRIDE:0000316
 name: MS1 based isotope labeling
-def: "Describes isotope labeling quantification techniques detectable at MS1 level." [PRIDE:PRIDE]
+def: "Describes isotope labeling quantification techniques detectable at MS1 level" [PRIDE:PRIDE]
 is_a: PRIDE:0000310 ! Isotope labeling
 
 [Term]
 id: PRIDE:0000317
 name: MS2 based isotope labeling
-def: "Describes isotope labeling quantification techniques detectable at MS1 level." [PRIDE:PRIDE]
+def: "Describes isotope labeling quantification techniques detectable at MS1 level" [PRIDE:PRIDE]
 is_a: PRIDE:0000310 ! Isotope labeling
 
 [Term]
 id: PRIDE:0000318
 name: 18O
-def: "The 18O quantification method relies on the differentiation of two samples using different stable isotopes of oxygen." [PRIDE:PRIDE]
+def: "The 18O quantification method relies on the differentiation of two samples using different stable isotopes of oxygen" [PRIDE:PRIDE]
 is_a: PRIDE:0000316 ! MS1 based isotope labeling
 
 [Term]
 id: PRIDE:0000319
 name: ICAT
-def: "Isotope-Coded Affinity Tags is an isotope labeling quantification technique and uses tags that consist of three elements." [PRIDE:PRIDE]
+def: "Isotope-Coded Affinity Tags is an isotope labeling quantification technique and uses tags that consist of three elements" [PRIDE:PRIDE]
 synonym: "Isotope-Coded Affinity Tags" EXACT []
 is_a: PRIDE:0000316 ! MS1 based isotope labeling
 
 [Term]
 id: PRIDE:0000320
 name: AQUA
-def: "AQUA is an isotope labeling based quantification technique that uses known peptides." [PRIDE:PRIDE]
+def: "AQUA is an isotope labeling based quantification technique that uses known peptides" [PRIDE:PRIDE]
 is_a: PRIDE:0000316 ! MS1 based isotope labeling
 
 [Term]
 id: PRIDE:0000321
 name: ICPL
-def: "Isotope-coded protein labels is an isotope labeling based quantification method where peptides are labelled with reagents of different masses." [PRIDE:PRIDE]
+def: "Isotope-coded protein labels is an isotope labeling based quantification method where peptides are labelled with reagents of different masses" [PRIDE:PRIDE]
 synonym: "Isotope-coded protein label" EXACT []
 is_a: PRIDE:0000316 ! MS1 based isotope labeling
 
 [Term]
 id: PRIDE:0000322
 name: emPAI
-def: "The Exponentially Modified Protein Abundance Index (emPAI) offers approximate, label-free, relative quantification of the proteins in a mixture based on protein coverage by the peptide matches in a database search result." [PRIDE:PRIDE]
+def: "The Exponentially Modified Protein Abundance Index (emPAI) offers approximate, label-free, relative quantification of the proteins in a mixture based on protein coverage by the peptide matches in a database search result" [PRIDE:PRIDE]
 synonym: "Exponentially Modified Protein Abundance Index" EXACT []
 is_a: PRIDE:0000312 ! Label free
 
 [Term]
 id: PRIDE:0000323
 name: TIC
-def: "The Total Ion Current (TIC) can be measured or calculated in order to target specific ions." [PRIDE:PRIDE]
+def: "The Total Ion Current (TIC) can be measured or calculated in order to target specific ions" [PRIDE:PRIDE]
 synonym: "Total Ion Current" EXACT []
 is_a: PRIDE:0000312 ! Label free
 
 [Term]
 id: PRIDE:0000324
 name: Quantification reagent
-def: "A reagent used for quantification." [PRIDE:PRIDE]
+def: "A reagent used for quantification" [PRIDE:PRIDE]
 is_a: PRIDE:0000017 ! Sample description additional parameter
 is_a: PRIDE:0000391 ! Quantification parameter
 
@@ -2123,13 +2123,13 @@ is_a: PRIDE:0000433 ! Reagents used in Labeled Method
 [Term]
 id: PRIDE:0000345
 name: ICAT light reagent
-def:"The ICAT light reagent is a chemical reagent that labels proteins for comparison with heavy reagents." [PRIDE:PRIDE]
+def:"The ICAT light reagent is a chemical reagent that labels proteins for comparison with heavy reagents" [PRIDE:PRIDE]
 is_a: PRIDE:0000344 ! ICAT reagent
 
 [Term]
 id: PRIDE:0000346
 name: ICAT heavy reagent
-def: "The ICAT heavy reagent is a chemical reagent used to label proteins for protein profiling." [PRIDE:PRIDE]
+def: "The ICAT heavy reagent is a chemical reagent used to label proteins for protein profiling" [PRIDE:PRIDE]
 is_a: PRIDE:0000344 ! ICAT reagent
 
 [Term]
@@ -2147,7 +2147,7 @@ is_a: PRIDE:0000347 ! ICPL reagent
 [Term]
 id: PRIDE:0000349
 name: ICPL 4 reagent
-def: "ICPLn4 reagent is a specific labeling compound that incorporates four deuterium (^2H) atoms, resulting in a mass shift of approximately 4.0251 Da per labeled amino acid compared to the light ICPL_0 reagent." [PRIDE:PRIDE]
+def: "ICPLn4 reagent is a specific labeling compound that incorporates four deuterium (^2H) atoms, resulting in a mass shift of approximately 4.0251 Da per labeled amino acid compared to the light ICPL_0 reagent" [PRIDE:PRIDE]
 is_a: PRIDE:0000347 ! ICPL reagent
 
 [Term]
@@ -2315,14 +2315,14 @@ is_a: PRIDE:0000006 ! Experiment additional parameter
 [Term]
 id: PRIDE:0000400
 name: Reference
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
-def: "Literature reference associated with one dataset (including the authors, title, year and journal details). The value field can be used for the PubMedID, or to specify if one manuscript is just submitted or accepted, but it does not have a PubMedID yet." [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
+def: "Literature reference associated with one dataset (including the authors, title, year and journal details). The value field can be used for the PubMedID, or to specify if one manuscript is just submitted or accepted, but it does not have a PubMedID yet" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000401
 name: Experimental information has been refined since this experiment was originally made publicly available
-def: "This means that the experimental information available has been improved, for instance precursor charges were added." [PRIDE:PRIDE]
+def: "This means that the experimental information available has been improved, for instance precursor charges were added" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
@@ -2334,15 +2334,15 @@ is_a: PRIDE:0000006 ! Experiment additional parameter
 [Term]
 id: PRIDE:0000403
 name: Associated file URI
-def: "URI of one external file associated to the PRIDE experiment (maybe through a PX submission)." [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "URI of one external file associated to the PRIDE experiment (maybe through a PX submission)" [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000404
 name: Associated raw file URI
 def: "URI of a raw data file associated to the PRIDE experiment (maybe through a PX submission)" [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000403 ! Associated file URI
 is_a: PRIDE:0000577 ! file uri
 
@@ -2355,138 +2355,138 @@ is_a: PRIDE:0000006 ! Experiment additional parameter
 [Term]
 id: PRIDE:0000406
 name: ProteomeCentral dataset URI
-def: "URI associated to one PX submission in ProteomeCentral." [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "URI associated to one PX submission in ProteomeCentral" [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000407
 name: Result file URI
-def: "URI of one file labeled as 'Result', associated to one PX submission." [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "URI of one file labeled as 'Result', associated to one PX submission" [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000403 ! Associated file URI
 is_a: PRIDE:0000577 ! file uri
 
 [Term]
 id: PRIDE:0000408
 name: Search engine output file URI
-def: "URI of one search engine output file associated to one PX submission." [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "URI of one search engine output file associated to one PX submission" [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000403 ! Associated file URI
 is_a: PRIDE:0000577 ! file uri
 
 [Term]
 id: PRIDE:0000409
 name: Peak list file URI
-def: "URI of one of one search engine output file associated to one PX submission." [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "URI of one of one search engine output file associated to one PX submission" [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000403 ! Associated file URI
 is_a: PRIDE:0000577 ! file uri
 
 [Term]
 id: PRIDE:0000410
 name: 'Other' type file URI
-def: "URI of one file labeled as 'Other', associated to one PX submission." [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "URI of one file labeled as 'Other', associated to one PX submission" [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000403 ! Associated file URI
 is_a: PRIDE:0000577 ! file uri
 
 [Term]
 id: PRIDE:0000411
 name: Dataset FTP location
-def: "FTP location of one entire PX data set." [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "FTP location of one entire PX data set" [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000412
 name: Dataset with no associated published manuscript
-def: "A dataset which does not have an associated published manuscript." [PRIDE:PRIDE]
+def: "A dataset which does not have an associated published manuscript" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000413
 name: Instrument name
-def: "The value of this term (related to one PRIDE experiment) can be used to provide the name of instruments that are not included in any other CV yet." [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+def: "The value of this term (related to one PRIDE experiment) can be used to provide the name of instruments that are not included in any other CV yet" [PRIDE:PRIDE]
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000414
 name: Peer-reviewed dataset
-def: "Dataset has been peer-reviewed somehow." [PRIDE:PRIDE]
+def: "Dataset has been peer-reviewed somehow" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000415
 name: Non peer-reviewed dataset
-def: "Dataset that has not been peer-reviewed by any means." [PRIDE:PRIDE]
+def: "Dataset that has not been peer-reviewed by any means" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000416
 name: Supported dataset by repository
-def: "The PX dataset is supported by and is available through the submission repository." [PRIDE:PRIDE]
+def: "The PX dataset is supported by and is available through the submission repository" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000417
 name: Unsupported dataset by repository
-def: "The PX dataset is not fully supported by the submission repository." [PRIDE:PRIDE]
+def: "The PX dataset is not fully supported by the submission repository" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000418
 name: Other member of protein ambiguity group
-def: "Accession of another protein that was assigned to the same protein ambiguity group. This term must be repeated to include all protein group members, except for itself." [PRIDE:PRIDE]
+def: "Accession of another protein that was assigned to the same protein ambiguity group. This term must be repeated to include all protein group members, except for itself" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000419
 name: b ion -H3PO4
-def: "B ion type with a neutral loss of a phosphate molecule." [PRIDE:PRIDE]
+def: "B ion type with a neutral loss of a phosphate molecule" [PRIDE:PRIDE]
 synonym: "b fragment ion -H3PO4" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
 id: PRIDE:0000420
 name: b ion -2H3PO4
-def: "B ion type with a neutral loss of 2 phosphate molecules." [PRIDE:PRIDE]
+def: "B ion type with a neutral loss of 2 phosphate molecules" [PRIDE:PRIDE]
 synonym: "b fragment ion -2H3PO4" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
 id: PRIDE:0000421
 name: b ion -3H3PO4
-def: "B ion type with a neutral loss of 3 phosphate molecules." [PRIDE:PRIDE]
+def: "B ion type with a neutral loss of 3 phosphate molecules" [PRIDE:PRIDE]
 synonym: "b fragment ion -3H3PO4" EXACT []
 is_a: PRIDE:0000194 ! b ion
 
 [Term]
 id: PRIDE:0000422
 name: y ion -H3PO4
-def: "Y ion type with a neutral loss of a phosphate molecule." [PRIDE:PRIDE]
+def: "Y ion type with a neutral loss of a phosphate molecule" [PRIDE:PRIDE]
 synonym: "y fragment ion -H3PO4" EXACT []
 is_a: PRIDE:0000193 ! y ion
 
 [Term]
 id: PRIDE:0000423
 name: y ion -2H3PO4
-def: "Y ion type with a neutral loss of 2 phosphate molecules." [PRIDE:PRIDE]
+def: "Y ion type with a neutral loss of 2 phosphate molecules" [PRIDE:PRIDE]
 synonym: "y fragment ion -2H3PO4" EXACT []
 is_a: PRIDE:0000193 ! y ion
 
 [Term]
 id: PRIDE:0000424
 name: y ion -3H3PO4
-def: "Y ion type with a neutral loss of 3 phosphate molecules." [PRIDE:PRIDE]
+def: "Y ion type with a neutral loss of 3 phosphate molecules" [PRIDE:PRIDE]
 synonym: "y fragment ion -3H3PO4" EXACT []
 is_a: PRIDE:0000193 ! y ion
 
 [Term]
 id: PRIDE:0000425
 name: MS1 intensity based label-free quantification method
-def: "A a widely used approach in mass spectrometry-based proteomics for quantifying protein abundances across different samples." [PRIDE:PRIDE]
+def: "A a widely used approach in mass spectrometry-based proteomics for quantifying protein abundances across different samples" [PRIDE:PRIDE]
 is_a: PRIDE:0000309 ! Gel-free quantification method
 
 [Term]
@@ -2530,7 +2530,7 @@ is_a: PRIDE:0000428 ! Bottom-up proteomics
 [Term]
 id: PRIDE:0000432
 name: Dataset with its publication pending
-def: "A dataset which has an associated manuscript pending for publication." [PRIDE:PRIDE]
+def: "A dataset which has an associated manuscript pending for publication" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
@@ -2590,44 +2590,44 @@ is_a: PRIDE:0000312 ! Label free
 [Term]
 id: PRIDE:0000442
 name: Tissue not applicable to dataset
-def: "Tissue not applicable to dataset." [PRIDE:PRIDE]
+def: "Tissue not applicable to dataset" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000443
 name: Original NCBI Peptidome submission files
-def: "The NCBI FTP location of the original Sample - Experiment level Peptidome submission data." [PRIDE:PRIDE]
+def: "The NCBI FTP location of the original Sample - Experiment level Peptidome submission data" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000444
 name: PRIDE experiment accession
-def: "Accession number of a given PRIDE experiment (called assay in the PRIDE-3 system)." [PRIDE:PRIDE]
+def: "Accession number of a given PRIDE experiment (called assay in the PRIDE-3 system)" [PRIDE:PRIDE]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000445
 name: PRIDE Cluster score
-def: "It is an integer that gives an indication about the quality of a peptide spectrum match in PRIDE-Q. It uses the PRIDE-Cluster algorithm (described in PMID: 23361086) and different criteria to assign it (number of spectra in a cluster, ratio of the predominant peptide identification in the cluster, etc)." [PRIDE:PRIDE]
+def: "It is an integer that gives an indication about the quality of a peptide spectrum match in PRIDE-Q. It uses the PRIDE-Cluster algorithm (described in PMID: 23361086) and different criteria to assign it (number of spectra in a cluster, ratio of the predominant peptide identification in the cluster, etc)" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000446
 name: PRIDE peptide score
-def: "Score used in PRIDE-Q to give an indication of the quality of a peptide spectrum match. It is described in PMID:16964243." [PRIDE:PRIDE]
+def: "Score used in PRIDE-Q to give an indication of the quality of a peptide spectrum match. It is described in PMID:16964243" [PRIDE:PRIDE]
 is_a: PRIDE:0000003 ! Peptide item additional parameter
 
 [Term]
 id: PRIDE:0000447
 name: SWATH MS
-def: "ABsciex Data Independent Acquisition method that consists of unfractionated samples acquisition by using duty cycles adapted to HPLC chromatography, acquiring sequential wide fragment ions spectra, typically covering the precursor mass space from 400 m/z to 1200 m/z on each duty cycle. Acquired data is interrogated by using libraries of peptide coordinates (normalised elution time, fragment ion masses and intensities). It is described in PMID:22261725." [PRIDE:PRIDE]
+def: "ABsciex Data Independent Acquisition method that consists of unfractionated samples acquisition by using duty cycles adapted to HPLC chromatography, acquiring sequential wide fragment ions spectra, typically covering the precursor mass space from 400 m/z to 1200 m/z on each duty cycle. Acquired data is interrogated by using libraries of peptide coordinates (normalised elution time, fragment ion masses and intensities). It is described in PMID:22261725" [PRIDE:PRIDE]
 is_a: PRIDE:0000450 ! Data-independent acquisition
 
 [Term]
 id: PRIDE:0000448
 name: Additional associated raw file URI
 def: "Additional URI of one raw data file associated to the PRIDE experiment (maybe through a PX submission). The URI is provided via an additional resource to PRIDE" [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000403 ! Associated file URI
 is_a: PRIDE:0000577 ! file uri
 
@@ -2635,39 +2635,39 @@ is_a: PRIDE:0000577 ! file uri
 id: PRIDE:0000449
 name: Gel image file URI
 def: "URI of one gel image file associated to one PX submission" [PRIDE:PRIDE]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000403 ! Associated file URI
 is_a: PRIDE:0000577 ! file uri
 
 [Term]
 id: PRIDE:0000450
 name: Data-independent acquisition
-def: "Predefined m/z ranges are interrogated either by fragmenting all ions entering the mass spectrometer at every single point in chromatographic time; or by dividing the m/z range into smaller m/z ranges for isolation and fragmentation. See review in PMID:24281846." [PRIDE:PRIDE]
+def: "Predefined m/z ranges are interrogated either by fragmenting all ions entering the mass spectrometer at every single point in chromatographic time; or by dividing the m/z range into smaller m/z ranges for isolation and fragmentation. See review in PMID:24281846" [PRIDE:PRIDE]
 is_a: PRIDE:0000428 ! Bottom-up proteomics
 is_a: PRIDE:0000659 ! Proteomics data acquisition method
 
 [Term]
 id: PRIDE:0000451
 name: MSE
-def: "Waters data independent acquisition method based on UPLC chromatography and MS acquisition of cycles of two spectra, in low and high energy respectively, in a QQ-TOF instrument. It is described in PMID: 16755610." [PRIDE:PRIDE]
+def: "Waters data independent acquisition method based on UPLC chromatography and MS acquisition of cycles of two spectra, in low and high energy respectively, in a QQ-TOF instrument. It is described in PMID: 16755610" [PRIDE:PRIDE]
 is_a: PRIDE:0000450 ! Data-independent acquisition
 
 [Term]
 id: PRIDE:0000452
 name: HDMSE
-def: "Waters data independent acquisition method, which consists of using an additional on-line separation dimension (Ion Mobility drift) and an MSE acquisition. It is described in PMID: 22811061." [PRIDE:PRIDE]
+def: "Waters data independent acquisition method, which consists of using an additional on-line separation dimension (Ion Mobility drift) and an MSE acquisition. It is described in PMID: 22811061" [PRIDE:PRIDE]
 is_a: PRIDE:0000450 ! Data-independent acquisition
 
 [Term]
 id: PRIDE:0000453
 name: PAcIFIC
-def: "Precursor Acquisition Independent From Ion Count. A Data Independent Acquisition method performed in ion traps that consists of the acquisition of 2.5 m/z width sequential windows over several injections of the same material, until a precursor m/z range of about 400 to 1200 m/z is covered. It is described in PMID: 21341720." [PRIDE:PRIDE]
+def: "Precursor Acquisition Independent From Ion Count. A Data Independent Acquisition method performed in ion traps that consists of the acquisition of 2.5 m/z width sequential windows over several injections of the same material, until a precursor m/z range of about 400 to 1200 m/z is covered. It is described in PMID: 21341720" [PRIDE:PRIDE]
 is_a: PRIDE:0000450 ! Data-independent acquisition
 
 [Term]
 id: PRIDE:0000454
 name: All-ion fragmentation
-def: "MS Data Independent Acquisition performed in Thermo Orbitrap instruments. It consists of the acquisition of cycles of two spectra, a precursor mass MS1 spectrum, and a fragment ions MS2 spectrum where a wide mass filter (typically over 800 m/z) is applied to the precursors. It is described in PMID: 20610777." [PRIDE:PRIDE]
+def: "MS Data Independent Acquisition performed in Thermo Orbitrap instruments. It consists of the acquisition of cycles of two spectra, a precursor mass MS1 spectrum, and a fragment ions MS2 spectrum where a wide mass filter (typically over 800 m/z) is applied to the precursors. It is described in PMID: 20610777" [PRIDE:PRIDE]
 is_a: PRIDE:0000450 ! Data-independent acquisition
 
 [Term]
@@ -2690,7 +2690,7 @@ def: "Domain-specific mass spectrometry experiment type focusing on the scientif
 [Term]
 id: PRIDE:0000458
 name: Metaproteomics
-def: "Studying all protein samples of diverse host environments like the human body, soil or sea water." [PRIDE:PRIDE]
+def: "Studying all protein samples of diverse host environments like the human body, soil or sea water" [PRIDE:PRIDE]
 is_a: PRIDE:0000457 ! Experiment Type
 synonym: "Community Proteomics" EXACT []
 synonym: "Environmental Proteomics" RELATED []
@@ -2698,66 +2698,66 @@ synonym: "Environmental Proteomics" RELATED []
 [Term]
 id: PRIDE:0000459
 name: Human Metaproteomics
-def: "Investigating both human host proteins and associated microbial proteins at the same time from human samples." [PRIDE:PRIDE]
+def: "Investigating both human host proteins and associated microbial proteins at the same time from human samples" [PRIDE:PRIDE]
 is_a: PRIDE:0000458 ! Metaproteomics
 
 [Term]
 id: PRIDE:0000460
 name: Proteogenomics
-comment: "Studies that use proteomic information to improve genome annotation. Proteogenomics approaches are also increasingly used in personalised medicine studies."
+comment: "Studies that use proteomic information to improve genome annotation. Proteogenomics approaches are also increasingly used in personalised medicine studies"
 is_a: PRIDE:0000457 ! Experiment Type
 
 [Term]
 id: PRIDE:0000461
 name: Multi-omics study
-def: "Studies that use various omics methods like proteomics, genomics, transcriptomics, metabolomics to analyse the same biological samples." [PRIDE:PRIDE]
+def: "Studies that use various omics methods like proteomics, genomics, transcriptomics, metabolomics to analyse the same biological samples" [PRIDE:PRIDE]
 is_a: PRIDE:0000457 ! Experiment Type
 
 [Term]
 id: PRIDE:0000462
 name: SONAR
-def: "Waters data independent acquisition method." [PRIDE:PRIDE]
+def: "Waters data independent acquisition method" [PRIDE:PRIDE]
 is_a: PRIDE:0000450 ! Data-independent acquisition 
 
 [Term]
 id: PRIDE:0000463
 name: PRM
-def: "Using Selected Reaction Monitoring (SRM) with parallel detection of all transitions in a single analysis." [PRIDE:PRIDE]
+def: "Using Selected Reaction Monitoring (SRM) with parallel detection of all transitions in a single analysis" [PRIDE:PRIDE]
 is_a: PRIDE:0000311 ! Selected Reaction Monitoring
 
 [Term]
 id: PRIDE:0000464
 name: Fasta file URI
 comment: URI of one external Fasta file associated to the PRIDE experiment (maybe through a PX submission).
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000465
 name: Spectral Library file URI
 comment: URI of one external Spectral Library file associated to the PRIDE experiment (maybe through a PX submission).
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000466
 name: Quantification result file URI
 comment: URI of one external Quantification file associated to the PRIDE experiment (maybe through a PX submission).
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000467
 name: MS Image file URI
 comment: URI of one external Mass spectrometry Image file associated to the PRIDE experiment (maybe through a PX submission).
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
 id: PRIDE:0000468
 name: Aspera Protocol
 comment: URI for an Aspera Download Protocol
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
+xref: value-type:xsd\:string "The allowed value-type for this CV term"
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
@@ -2768,7 +2768,7 @@ is_a: PRIDE:0000006 ! Experiment additional parameter
 [Term]
 id: PRIDE:0000470
 name: File Properties
-def: "PRIDE File Properties for all type of files." [PRIDE:PRIDE]
+def: "PRIDE File Properties for all type of files" [PRIDE:PRIDE]
 
 [Term]
 id: PRIDE:0000471
@@ -2779,73 +2779,73 @@ is_a: PRIDE:0000470 ! File Properties
 [Term]
 id: PRIDE:0000472
 name: MS min charge
-def: "Minimum charge for all precursor in the file." [PRIDE:PRIDE]
+def: "Minimum charge for all precursor in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! MS File Properties
 
 [Term]
 id: PRIDE:0000473
 name: MS max charge
-def: "Maximum charge for all precursor in the file." [PRIDE:PRIDE]
+def: "Maximum charge for all precursor in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! MS File Properties
 
 [Term]
 id: PRIDE:0000474
 name: MS min RT
-def: "Minimum retention time in the File." [PRIDE:PRIDE]
+def: "Minimum retention time in the File" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! MS File Properties
 
 [Term]
 id: PRIDE:0000475
 name: MS max RT
-def: "Maximum retention time in the file." [PRIDE:PRIDE]
+def: "Maximum retention time in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! MS File Properties
 
 [Term]
 id: PRIDE:0000476
 name: MS min MZ
-def: "Minimum precursor mass to charge in the file." [PRIDE:PRIDE]
+def: "Minimum precursor mass to charge in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! MS File Properties
 
 [Term]
 id: PRIDE:0000477
 name: MS max MZ
-def: "Maximum precursor mass to charge in the file." [PRIDE:PRIDE]
+def: "Maximum precursor mass to charge in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! MS File Properties
 
 [Term]
 id: PRIDE:0000478
 name: Number of scans
-def: "Total number of scans in the file." [PRIDE:PRIDE]
+def: "Total number of scans in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! MS File Properties
 
 [Term]
 id: PRIDE:0000479
 name: MS scan range
-def: "Range of scan number in the ms file." [PRIDE:PRIDE]
+def: "Range of scan number in the ms file" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! File Properties
 
 [Term]
 id: PRIDE:0000480
 name: Number of MS
-def: "Number of MS in the file." [PRIDE:PRIDE]
+def: "Number of MS in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000471 ! MS File Properties
 
 [Term]
 id: PRIDE:0000481
 name: Number of MS1 spectra
-def: "Number of MS1 spectra." [PRIDE:PRIDE]
+def: "Number of MS1 spectra" [PRIDE:PRIDE]
 is_a: PRIDE:0000480 ! Number of MS
 
 [Term]
 id: PRIDE:0000482
 name: Number of MS2 spectra
-def: "Number of MS2 spectra in the file." [PRIDE:PRIDE]
+def: "Number of MS2 spectra in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000480 ! Number of MS
 
 [Term]
 id: PRIDE:0000483
 name: Number of MS3 spectra
-def: "Total number of MS3 spectra in the file." [PRIDE:PRIDE]
+def: "Total number of MS3 spectra in the file" [PRIDE:PRIDE]
 is_a: PRIDE:0000480 ! Number of MS
 
 [Term]
@@ -2857,12 +2857,12 @@ is_a: PRIDE:0000470 ! File Properties
 [Term]
 id: PRIDE:0000484
 name: Result analysis parameters
-def: "The result analysis parameters is a term to group all the parameters for proteomics data analysis." [PRIDE:PRIDE]
+def: "The result analysis parameters is a term to group all the parameters for proteomics data analysis" [PRIDE:PRIDE]
 
 [Term]
 id: PRIDE:0000485
 name: Global result parameters
-def: "Result analysis parameters share by multiple search engine and Quantiative tools." [PRIDE:PRIDE]
+def: "Result analysis parameters share by multiple search engine and Quantiative tools" [PRIDE:PRIDE]
 is_a: PRIDE:0000484 ! Result analysis parameters
 
 [Term]
@@ -2873,61 +2873,61 @@ is_a: PRIDE:0000484 ! Result analysis parameters
 [Term]
 id: PRIDE:0000487
 name: Min charge
-def: "Minimum charge of precursor to be search." [PRIDE:PRIDE]
+def: "Minimum charge of precursor to be search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000488
 name: Max charge
-def: "Maximum charge of precursor to be search." [PRIDE:PRIDE]
+def: "Maximum charge of precursor to be search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000489
 name: Min RT
-def: "Min Retention time for precursor to be search." [PRIDE:PRIDE]
+def: "Min Retention time for precursor to be search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000490
 name: Max RT
-def: "Maximum precursor RT to be search." [PRIDE:PRIDE]
+def: "Maximum precursor RT to be search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000491
 name: Number of missed cleavages
-def: "Number of missed cleavages." [PRIDE:PRIDE]
+def: "Number of missed cleavages" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000492
 name: Max peptide AA length
-def: "Max peptide amino acid length for search." [PRIDE:PRIDE]
+def: "Max peptide amino acid length for search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000493
 name: Min peptide AA length
-def: "Minimum peptide amino acid length for search." [PRIDE:PRIDE]
+def: "Minimum peptide amino acid length for search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000494
 name: Min precursor MZ
-def: "Min precursor MZ (mass) for precursor to search." [PRIDE:PRIDE]
+def: "Min precursor MZ (mass) for precursor to search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000495
 name: Max precursor MZ
-def: "Max precursor MZ (mass) for precursor to search." [PRIDE:PRIDE]
+def: "Max precursor MZ (mass) for precursor to search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000496
 name: Min peak length
-def: "Min number of peaks in the spectrum to be search." [PRIDE:PRIDE]
+def: "Min number of peaks in the spectrum to be search" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
@@ -2981,25 +2981,25 @@ is_a: PRIDE:0000485 ! Global result parameters
 [Term]
 id: PRIDE:0000505
 name: Individual Accession
-def: "Accession or Code of the individual in the sample." [PRIDE:PRIDE]
+def: "Accession or Code of the individual in the sample" [PRIDE:PRIDE]
 is_a: PRIDE:0000017 !  Sample description additional parameter
 
 [Term]
 id: PRIDE:0000506
 name: Number identified proteins
-def: "Total number of reported proteins. This property can be used to report the number of proteins identified in an Assay or experiment." [PRIDE:PRIDE]
+def: "Total number of reported proteins. This property can be used to report the number of proteins identified in an Assay or experiment" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000507
 name: Number of identified peptides
-def: "Total number of identified peptides in an experiment or assay." [PRIDE:PRIDE]
+def: "Total number of identified peptides in an experiment or assay" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
 id: PRIDE:0000508
 name: Number of modified peptides
-def: "The total number of peptides identified with post-translational modifications." [PRIDE:PRIDE]
+def: "The total number of peptides identified with post-translational modifications" [PRIDE:PRIDE]
 is_a: PRIDE:0000485 ! Global result parameters
 
 [Term]
@@ -3011,7 +3011,7 @@ is_a: PRIDE:0000485 ! Global result parameters
 [Term]
 id: PRIDE:0000510
 name: File size
-def: "The size of the file in MB." [PRIDE:PRIDE]
+def: "The size of the file in MB" [PRIDE:PRIDE]
 is_a: PRIDE:0000470 ! File Properties
 
 [Term]
@@ -3221,27 +3221,27 @@ is_a: PRIDE:0000540 ! ICAT channel label
 [Term]
 id: PRIDE:0000543
 name: Quality Control
-def: "MS experiments conducted to control the quality of measurements. Includes the acquisition of samples for SST and longitudinal monitoring." [PRIDE:PRIDE]
+def: "MS experiments conducted to control the quality of measurements. Includes the acquisition of samples for SST and longitudinal monitoring" [PRIDE:PRIDE]
 comment: Example description of such experiments in 10.1002/pmic.201000578
 is_a: PRIDE:0000457 ! Experiment Type
 
 [Term]
 id: PRIDE:0000544
 name: Quality Control Sample
-def: "Sample with known content and quantities designed to control the consistent quality of measurement for a particular method and settings." [PRIDE:PRIDE]
+def: "Sample with known content and quantities designed to control the consistent quality of measurement for a particular method and settings" [PRIDE:PRIDE]
 comment: Example description of such samples in 10.1002/pmic.201000578
 is_a: PRIDE:0000017 ! Sample description additional parameter
 
 [Term]
 id: PRIDE:0000545
 name: QC1 sample
-def: "QC1 sample as described in 10.1371/journal.pone.0189209." [PRIDE:PRIDE]
+def: "QC1 sample as described in 10.1371/journal.pone.0189209" [PRIDE:PRIDE]
 is_a: PRIDE:0000544 ! Quality Control Sample
 
 [Term]
 id: PRIDE:0000546
 name: QC2 sample
-def: "QC2 sample as described in 10.1371/journal.pone.0189209." [PRIDE:PRIDE]
+def: "QC2 sample as described in 10.1371/journal.pone.0189209" [PRIDE:PRIDE]
 is_a: PRIDE:0000544 ! Quality Control Sample
 
 [Term]
@@ -3270,97 +3270,97 @@ is_a: MS:1000451 ! mass analyzer
 [Term]
 id: PRIDE:0000550
 name: Fractionation method
-def: "Umbrella term for different types of fractionation methods." [PRIDE:PRIDE]
+def: "Umbrella term for different types of fractionation methods" [PRIDE:PRIDE]
 is_a: PRIDE:0000021 ! Fractionation
 
 [Term]
 id: PRIDE:0000551
 name: Separation method
-def: "Umbrella term for different types of fractionation methods." [PRIDE:PRIDE]
+def: "Umbrella term for different types of fractionation methods" [PRIDE:PRIDE]
 is_a: PRIDE:0000022 ! Separation
 
 [Term]
 id: PRIDE:0000552
 name: Off-gel electrophoresis
-def: "Fractionate peptides into discrete liquid fractions based on isoelectric electrophoresis (10.1002/elps.200390030)." [PRIDE:PRIDE]
+def: "Fractionate peptides into discrete liquid fractions based on isoelectric electrophoresis (10.1002/elps.200390030)" [PRIDE:PRIDE]
 is_a: PRIDE:0000550 ! Fractionation method
 
 [Term]
 id: PRIDE:0000553
 name: Isoelectric focusing
-def: "An electrophoresis method for the separation of amphoteric analytes according to their isoelectric points by the application of an electric field along a pH gradient." [PRIDE:PRIDE]
+def: "An electrophoresis method for the separation of amphoteric analytes according to their isoelectric points by the application of an electric field along a pH gradient" [PRIDE:PRIDE]
 is_a: PRIDE:0000550 ! Fractionation method
 
 [Term]
 id: PRIDE:0000554
 name: Hydrophilic interaction chromatography (HILIC)
-def: "Liquid chromatography where the stationary phase is hydrophilic, the mobile phase is organic and separation is achieved based on polarity." [PRIDE:PRIDE]
+def: "Liquid chromatography where the stationary phase is hydrophilic, the mobile phase is organic and separation is achieved based on polarity" [PRIDE:PRIDE]
 is_a: PRIDE:0000562 ! Normal-phase liquid chromatography (NP)
 
 [Term]
 id: PRIDE:0000555
 name: ERLIC
-def: "Electrostatic repulsion hydrophilic interaction chromatography (ERLIC). Hydrophilic interaction chromatography where the chromatography column is an ion-exchange column and the mobile phase is predominantly organic." [PRIDE:PRIDE]
+def: "Electrostatic repulsion hydrophilic interaction chromatography (ERLIC). Hydrophilic interaction chromatography where the chromatography column is an ion-exchange column and the mobile phase is predominantly organic" [PRIDE:PRIDE]
 is_a: PRIDE:0000562 ! Normal-phase liquid chromatography (NP)
 
 [Term]
 id: PRIDE:0000556
 name: Ion-exchange chromatography 
-def: "A chromatography method where the separation is caused by differences in ion-exchange affinity." [PRIDE:PRIDE]
+def: "A chromatography method where the separation is caused by differences in ion-exchange affinity" [PRIDE:PRIDE]
 is_a: PRIDE:0000565 ! High-performance liquid chromatography
 
 [Term]
 id: PRIDE:0000557
 name: Size-exclusion chromatography (SEC)
-def: "A chromatography method where the separation is caused by differences in molecular size." [PRIDE:PRIDE]
+def: "A chromatography method where the separation is caused by differences in molecular size" [PRIDE:PRIDE]
 is_a: PRIDE:0000565 ! High-performance liquid chromatography
 
 [Term]
 id: PRIDE:0000558
 name: Strong anion-exchange chromatography (SAX)
-def: "A chromatography method with the stationary phase being a strong anion exchanger." [PRIDE:PRIDE]
+def: "A chromatography method with the stationary phase being a strong anion exchanger" [PRIDE:PRIDE]
 is_a: PRIDE:0000556 ! Ion-exchange chromatography
 
 [Term]
 id: PRIDE:0000559
 name: Weak anion-exchange chromatography (WAX)
-def: "A chromatography method with the stationary phase being a weak anion exchanger." [PRIDE:PRIDE]
+def: "A chromatography method with the stationary phase being a weak anion exchanger" [PRIDE:PRIDE]
 is_a: PRIDE:0000556 ! Ion-exchange chromatography
 
 [Term]
 id: PRIDE:0000560
 name: Weak cation-exchange chromatography (WCX)
-def: "A chromatography method with the stationary phase being a weak cation exchanger." [PRIDE:PRIDE]
+def: "A chromatography method with the stationary phase being a weak cation exchanger" [PRIDE:PRIDE]
 is_a: PRIDE:0000556 ! Ion-exchange chromatography
 
 [Term]
 id: PRIDE:0000561
 name: Strong cation-exchange chromatography (SCX)
-def: "A chromatography method with the stationary phase being a strong cation exchanger." [PRIDE:PRIDE]
+def: "A chromatography method with the stationary phase being a strong cation exchanger" [PRIDE:PRIDE]
 is_a: PRIDE:0000556 ! Ion-exchange chromatography
 
 [Term]
 id: PRIDE:0000562
 name: Normal-phase liquid chromatography (NP)
-def: "Liquid chromatography where the stationary phase is more polar than the mobile phase. This is the default for liquid chromatography." [PRIDE:PRIDE]
+def: "Liquid chromatography where the stationary phase is more polar than the mobile phase. This is the default for liquid chromatography" [PRIDE:PRIDE]
 is_a: PRIDE:0000565 ! High-performance liquid chromatography
 
 [Term]
 id: PRIDE:0000563
 name: Reversed-phase chromatography (RP)
-def: "Liquid chromatography where the mobile phase is significantly more polar than the stationary phase." [PRIDE:PRIDE]
+def: "Liquid chromatography where the mobile phase is significantly more polar than the stationary phase" [PRIDE:PRIDE]
 is_a: PRIDE:0000565 ! High-performance liquid chromatography
 
 [Term]
 id: PRIDE:0000564
 name: High-pH reversed-phase chromatography (hpHRP)
-def: "Liquid chromatography where the mobile phase is of high pH and significantly more polar than the stationary phase." [PRIDE:PRIDE]
+def: "Liquid chromatography where the mobile phase is of high pH and significantly more polar than the stationary phase" [PRIDE:PRIDE]
 is_a: PRIDE:0000563 ! Reversed-phase chromatography (RP)
 
 [Term]
 id: PRIDE:0000565
 name: High-performance liquid chromatography
-def: "Column chromatography where the mobile phase is a liquid, the stationary phase consists of very small particles and the inlet pressure is relatively high." [PRIDE:PRIDE]
+def: "Column chromatography where the mobile phase is a liquid, the stationary phase consists of very small particles and the inlet pressure is relatively high" [PRIDE:PRIDE]
 xref: http://purl.obolibrary.org/obo/CHMO_0001009
 is_a: PRIDE:0000550 ! Fractionation method
 is_a: PRIDE:0000551 ! Separation method
@@ -3368,7 +3368,7 @@ is_a: PRIDE:0000551 ! Separation method
 [Term]
 id: PRIDE:0000566
 name: High-resolution isoelectric focusing (HiRIEF)
-def: "An electrophoresis method with significantly higher resolution than common isoelectric focusing methods." [PRIDE:PRIDE]
+def: "An electrophoresis method with significantly higher resolution than common isoelectric focusing methods" [PRIDE:PRIDE]
 is_a: PRIDE:0000553 ! Isoelectric focusing
 
 [Term]
@@ -3393,32 +3393,32 @@ is_a: PRIDE:0000567 ! Gel electrophoresis
 [Term]
 id: PRIDE:0000570
 name: Decoy protein
-def: "Indicates that this protein identification comes from the used decoy database." [PRIDE:PRIDE]
+def: "Indicates that this protein identification comes from the used decoy database" [PRIDE:PRIDE]
 is_a: PRIDE:0000004 ! Identification additional parameter
 
 [Term]
 id: PRIDE:0000571
 name: Quantification software
-def: "A software that perform protein quantification using mass spectrometry data." [PRIDE:PRIDE]
+def: "A software that perform protein quantification using mass spectrometry data" [PRIDE:PRIDE]
 
 [Term]
 id: PRIDE:0000572
 name: OpenMS
-def: "OpenMS is an open-source software C++ library for LC-MS data management and analyses. It offers an infrastructure for rapid development of mass spectrometry related software." [PRIDE:PRIDE]
+def: "OpenMS is an open-source software C++ library for LC-MS data management and analyses. It offers an infrastructure for rapid development of mass spectrometry related software" [PRIDE:PRIDE]
 is_a: PRIDE:0000571 ! Quantification software
 is_a: PRIDE:0000573 ! Identification software
 
 [Term]
 id: PRIDE:0000573
 name: Identification software
-def: "A software that perform peptide/protein identification using mass spectrometry data." [PRIDE:PRIDE]
+def: "A software that perform peptide/protein identification using mass spectrometry data" [PRIDE:PRIDE]
 
 creation_date: 2020-05-12T11:58:52Z
 
 [Term]
 id: PRIDE:0000574
 name: MaxQuant
-def: "MaxQuant is a quantitative proteomics software package designed for analyzing large mass-spectrometric data sets. It is specifically aimed at high-resolution MS data." [PRIDE:PRIDE]
+def: "MaxQuant is a quantitative proteomics software package designed for analyzing large mass-spectrometric data sets. It is specifically aimed at high-resolution MS data" [PRIDE:PRIDE]
 is_a: PRIDE:0000571 ! Quantification software
 is_a: PRIDE:0000573 ! Identification software
 
@@ -3526,7 +3526,7 @@ is_a: PRIDE:0000001 ! Protocol step description additional parameter
 [Term]
 id: PRIDE:0000589
 name: EThcD
-def: "A dissociation process combining electron-transfer and higher-energy collision dissociation (EThcD). It combines ETD (reaction time) followed by HCD (activation energy)." [PRIDE:PRIDE]
+def: "A dissociation process combining electron-transfer and higher-energy collision dissociation (EThcD). It combines ETD (reaction time) followed by HCD (activation energy)" [PRIDE:PRIDE]
 is_a: MS:1000044 ! dissociation method
 is_a: PRIDE:0000644 ! MS2 dissociation method
 is_a: PRIDE:0000645 ! MS3 dissociation method
@@ -3559,7 +3559,7 @@ is_a: PRIDE:0000645 ! MS3 dissociation method
 [Term]
 id: MS:1000045
 name: collision energy
-def: "Energy for an ion experiencing collision with a stationary gas particle resulting in dissociation of the ion." [PRIDE:PRIDE]
+def: "Energy for an ion experiencing collision with a stationary gas particle resulting in dissociation of the ion" [PRIDE:PRIDE]
 is_a: PRIDE:0000001 ! Protocol step description additional parameter
 
 [Term]
@@ -3928,7 +3928,7 @@ is_a: PRIDE:0000638 ! Instrument model
 [Term]
 id: PRIDE:0000655
 name: Olink Target 96
-def: "Olink Target 96 is a proteomics platform offering targeted analysis of 92 specific protein biomarkers per panel using proximity extension assay (PEA) technology." [PRIDE:PRIDE]
+def: "Olink Target 96 is a proteomics platform offering targeted analysis of 92 specific protein biomarkers per panel using proximity extension assay (PEA) technology" [PRIDE:PRIDE]
 is_a: PRIDE:0000672 ! Olink Target
 
 [Term]
@@ -3940,7 +3940,7 @@ is_a: PRIDE:0000671 ! Olink Explore
 [Term]
 id: PRIDE:0000657
 name: Olink Explore 3072/384
-def: "Olink Explore 3072 includes eight 384-plex panels for efficient, large-scale, disease- and process-focused studies." [PRIDE:PRIDE]
+def: "Olink Explore 3072 includes eight 384-plex panels for efficient, large-scale, disease- and process-focused studies" [PRIDE:PRIDE]
 is_a: PRIDE:0000671 ! Olink Explore
 
 [Term]
@@ -3977,7 +3977,7 @@ is_a: PRIDE:0000661 ! Differential mobility spectrometry
 [Term]
 id: PRIDE:0000663
 name: technology type
-def: "The technology type or platform used to perform the study." [EFO:EFO_0005521]
+def: "The technology type or platform used to perform the study" [EFO:EFO_0005521]
 is_a: PRIDE:0000006 ! Experiment additional parameter
 
 [Term]
@@ -3989,7 +3989,7 @@ is_a: PRIDE:0000663 ! technology type
 [Term]
 id: PRIDE:0000665
 name: Glycoproteomics
-def: "Study of proteins that identifies, catalogs, and characterizes those proteins that contain carbohydrates as posttranslational modifications." [PRIDE:PRIDE]
+def: "Study of proteins that identifies, catalogs, and characterizes those proteins that contain carbohydrates as posttranslational modifications" [PRIDE:PRIDE]
 is_a: PRIDE:0000457! Experiment Type
 
 [Term]
@@ -4025,13 +4025,13 @@ is_a: PRIDE:0000669 ! TMT18PLEX
 [Term]
 id: PRIDE:0000671
 name: Olink Explore
-def: "Olink Explore is a high-throughput proteomics platform that quantifies protein biomarkers across multiple samples using proximity extension assay (PEA) technology." [PRIDE:PRIDE]
+def: "Olink Explore is a high-throughput proteomics platform that quantifies protein biomarkers across multiple samples using proximity extension assay (PEA) technology" [PRIDE:PRIDE]
 is_a: PRIDE:0000654 ! Olink instrument model
 
 [Term]
 id: PRIDE:0000672
 name: Olink Target
-def: "Olink Target is a proteomics platform designed for focused, customizable analysis of specific protein biomarker panels using proximity extension assay (PEA) technology." [PRIDE:PRIDE]
+def: "Olink Target is a proteomics platform designed for focused, customizable analysis of specific protein biomarker panels using proximity extension assay (PEA) technology" [PRIDE:PRIDE]
 is_a: PRIDE:0000654 ! Olink instrument model
 
 


### PR DESCRIPTION
In this PR: 

- One term has been updated. 
- 25 terms has been deleted. We can't find then in PRIDE ontology in any dataset. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release metadata with a new version number and revised contributor information.
  
- **Refactor**
  - Removed outdated terms related to subsample details.
  - Refined definitions for clarity, including adjustments to score naming and punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->