### PR TITLE
Changing definition of PRIDE:0000430

### DIFF
--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -2498,7 +2498,7 @@ is_a: PRIDE:0000428 ! Bottom-up proteomics
 [Term]
 id: PRIDE:0000430
 name: Chemical cross-linking coupled with mass spectrometry proteomics
-def: "Chemical cross-linking of proteins coupled with mass spectrometry analysis (CXMS) to provide information about protein folding and protein-protein interaction" [PRIDE:PRIDE]
+def: "Chemical cross-linking of proteins coupled with mass spectrometry analysis to provide information about protein folding and protein-protein interaction" [PRIDE:PRIDE]
 is_a: PRIDE:0000428 ! Bottom-up proteomics
 
 [Term]


### PR DESCRIPTION
### **User description**
_name: Chemical cross-linking coupled with mass spectrometry proteomics_

**OLD Definition:** "Chemical cross-linking of proteins coupled with mass spectrometry analysis **(CXMS)** to provide information about protein folding and protein-protein interaction" [PRIDE:PRIDE]

**NEW Definition:** "Chemical cross-linking of proteins coupled with mass spectrometry analysis to provide information about protein folding and protein-protein interaction" [PRIDE:PRIDE]


___

### **PR Type**
Other


___

### **Description**
- Remove abbreviation "(CXMS)" from term definition


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pride_cv.obo</strong><dd><code>Remove CXMS abbreviation from definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pride_cv.obo

- Removed "(CXMS)" abbreviation from PRIDE:0000430 definition


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/pride-ontology/pull/154/files#diff-a0aa916f263b3df520de95c3b47eace77bbaa05edb0914ee42d95574e9c9c7be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the term definition for PRIDE:0000430 by removing the CXMS acronym from the description of Chemical cross-linking coupled with mass spectrometry proteomics.
  - Definition text otherwise unchanged; no modifications to ontology structure, identifiers, or relationships.
  - Users will see a clearer, less ambiguous description in interfaces and exports that display term definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->