### PR TITLE
Add MS min/max IM terms for ion mobility experiments

### DIFF
--- a/pride_cv.obo
+++ b/pride_cv.obo
@@ -5128,3 +5128,15 @@ name: sdrf annotation tool
 def: "The software tool, script, or manual curation method used to generate or annotate SDRF metadata and column values" [PRIDE:PRIDE]
 is_a: PRIDE:0000470 ! File Properties
 
+[Term]
+id: PRIDE:0000841
+name: MS min IM
+def: "Minimum ion mobility value in the file" [PRIDE:PRIDE]
+is_a: PRIDE:0000471 ! MS File Properties
+
+[Term]
+id: PRIDE:0000842
+name: MS max IM
+def: "Maximum ion mobility value in the file" [PRIDE:PRIDE]
+is_a: PRIDE:0000471 ! MS File Properties
+


### PR DESCRIPTION
## Summary
- Adds two new ontology terms for ion mobility values under MS File Properties (`PRIDE:0000471`):
  - `PRIDE:0000841` — **MS min IM**: Minimum ion mobility value in the file
  - `PRIDE:0000842` — **MS max IM**: Maximum ion mobility value in the file
- Follows the existing pattern of min/max pairs (charge, RT, MZ) already in the ontology

These terms enable annotation of ion mobility ranges in MS data files, supporting ion mobility experiments (e.g., TIMS, FAIMS).

Related discussion: https://github.com/bigbio/proteomics-sample-metadata/pull/796#issuecomment-3870700154