### PR TITLE
Upgrade GitHub Actions and Java version to 21

### DIFF
--- a/.github/workflows/validate-owl.yaml
+++ b/.github/workflows/validate-owl.yaml
@@ -13,16 +13,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin' # Install JDK from Eclipse Adoptium
-          java-version: '11'
+          java-version: '21'
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## Summary
Updated the CI/CD workflow to use newer versions of GitHub Actions and upgraded the Java runtime from version 11 to version 21.

## Key Changes
- Upgraded `actions/checkout` from v3 to v4
- Upgraded `actions/setup-java` from v3 to v4
- Upgraded `actions/cache` from v3 to v4
- Updated Java version from 11 to 21 (using Temurin distribution)

## Details
This change modernizes the CI/CD pipeline by adopting the latest stable versions of GitHub Actions and moving to Java 21, which provides improved performance, new language features, and better long-term support. The Temurin distribution from Eclipse Adoptium remains the source for the JDK installation.

https://claude.ai/code/session_01VJ116mBJ5m7aQ3D7uwGvTF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow tool versions to latest stable releases: upgraded checkout action to v4, upgraded setup-java action to v4 with Java runtime updated to version 21, and upgraded cache action to v4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->