### PR TITLE
ci: bump outdated action versions in update-owl workflow

### DIFF
--- a/.github/workflows/update-owl.yaml
+++ b/.github/workflows/update-owl.yaml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Extract version from OBO
         run: |
           CV_VERSION=`grep data-version pride_cv.obo | grep -oP "(\d+.\d+.\d+)"`
@@ -35,7 +35,7 @@ jobs:
           rm tmp_unimod.obo
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.PRIDE_CV_GITHUB_TOKEN }}
           commit-message: Update PRIDE OWL file
@@ -53,7 +53,7 @@ jobs:
           number: ${{ steps.cpr.outputs.pull-request-number }}
       - name: Merge pull request
         if: (steps.cpr.outputs.pull-request-operation == 'created' ||	steps.cpr.outputs.pull-request-operation == 'updated')
-        uses: peter-evans/enable-pull-request-automerge@v2
+        uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.PRIDE_CV_GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Summary

Bumps the three outdated GitHub Actions in `.github/workflows/update-owl.yaml` to current majors. All run on Node 20.

- `actions/checkout`: `v3` → `v4`
- `peter-evans/create-pull-request`: `v4` → `v6`
- `peter-evans/enable-pull-request-automerge`: `v2` → `v3`

## Notes

- `validate-obo.yml` and `validate-owl.yaml` already track current majors (`actions/checkout@v4`, `actions/setup-java@v4`, `actions/cache@v4`, `actions/upload-artifact@v4`) — no changes needed there.
- The `mathieudutour/github-tag-action@v5.6 → v6.2` bump is handled in the issue #179 branch (PR for that branch separately) and is intentionally omitted here to avoid merge conflicts.
- `juliangruber/approve-pull-request-action@v1` is left as-is (no widely-adopted v2 release at time of writing).

## Test plan

- [ ] Wait for next push to `master` to trigger the `Update OWL` workflow and verify it completes without `set-output` deprecation warnings or Node 16 deprecation warnings
- [ ] Confirm the auto-PR for the OWL update is created, approved, and auto-merged successfully


---
_Generated by [Claude Code](https://claude.ai/code/session_01QMbMZLUWuXzkewF94uhym9)_